### PR TITLE
Fix: Sudo group members list conversion error

### DIFF
--- a/tasks/Cat1/UBTU24-60xxxx.yml
+++ b/tasks/Cat1/UBTU24-60xxxx.yml
@@ -69,7 +69,7 @@
 
     - name: HIGH | UBTU-24-600130 | AUDIT | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Remove members
       ansible.builtin.set_fact:
-        discovered_sudo_group_users_list: "{{ discovered_sudo_group_users.stdout | split(',') }} "
+        discovered_sudo_group_users_list: "{{ discovered_sudo_group_users.stdout | split(',') }}"
 
     - name: HIGH | UBTU-24-600130 | PATCH | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Ensure member exist
       ansible.builtin.user:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
This pull request fixes a bug in the task that manages sudo group members (UBTU-24-600130).

A `set_fact` task that registers `discovered_sudo_group_users_list` had an extra space at the end of the expression, causing the Jinja2 expression to be interpreted as a string representation of a list (e.g., "[ 'user1', 'user2' ]") instead of a native YAML list.
This caused the subsequent task loop to iterate over individual characters of the string, leading to failures with the gpasswd command.

The bug was corrected by removing this single trailing space, located just before the closing double quote.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
Executed the role against an Ubuntu 24.04 host.

* **Before:** The playbook would fail on the task designed to remove sudo users due to the variable parsing error.
* **After:** With the space removed, the task completes successfully and manages sudo group membership as intended.

