### PR TITLE
V1R3 QA: Full QA pass on Ubuntu 24.04 STIG V1R3

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,5 @@
 ---
 
-parseable: true
 quiet: true
 skip_list:
   - 'package-latest'

--- a/.github/workflows/devel_pipeline_validation.yml
+++ b/.github/workflows/devel_pipeline_validation.yml
@@ -1,162 +1,162 @@
 ---
 
-  name: Devel pipeline
+name: Devel pipeline
 
-  on: # yamllint disable-line rule:truthy
-    pull_request_target:
-      types: [opened, reopened, synchronize]
-      branches:
-        - devel
-        - benchmark*
-      paths:
-        - '**.yml'
-        - '**.sh'
-        - '**.j2'
-        - '**.ps1'
-        - '**.cfg'
-    # Allow manual running of workflow
-    workflow_dispatch:
+on: # yamllint disable-line rule:truthy
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - devel
+      - benchmark*
+    paths:
+      - '**.yml'
+      - '**.sh'
+      - '**.j2'
+      - '**.ps1'
+      - '**.cfg'
+  # Allow manual running of workflow
+  workflow_dispatch:
 
-  # A workflow run is made up of one or more jobs
-  # that can run sequentially or in parallel
-  jobs:
-    # This will create messages for first time contributers and direct them to the Discord server
-    welcome:
-      runs-on: ubuntu-latest
+# A workflow run is made up of one or more jobs
+# that can run sequentially or in parallel
+jobs:
+  # This will create messages for first time contributers and direct them to the Discord server
+  welcome:
+    runs-on: ubuntu-latest
 
-      permissions:
-        issues: write
-        pull-requests: write
+    permissions:
+      issues: write
+      pull-requests: write
 
-      steps:
-        - uses: actions/first-interaction@main
-          with:
-            repo_token: ${{ secrets.GITHUB_TOKEN }}
-            issue_message: |-
-                Congrats on opening your first issue and thank you for taking the time to help improve Ansible-Lockdown!
-                Please join in the conversation happening on the [Discord Server](https://www.lockdownenterprise.com/discord) as well.
-            pr_message: |-
-                Congrats on opening your first pull request and thank you for taking the time to help improve Ansible-Lockdown!
-                Please join in the conversation happening on the [Discord Server](https://www.lockdownenterprise.com/discord) as well.
+    steps:
+      - uses: actions/first-interaction@main
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |-
+              Congrats on opening your first issue and thank you for taking the time to help improve Ansible-Lockdown!
+              Please join in the conversation happening on the [Discord Server](https://www.lockdownenterprise.com/discord) as well.
+          pr_message: |-
+              Congrats on opening your first pull request and thank you for taking the time to help improve Ansible-Lockdown!
+              Please join in the conversation happening on the [Discord Server](https://www.lockdownenterprise.com/discord) as well.
 
-    # This workflow contains a single job that tests the playbook
-    playbook-test:
-      # The type of runner that the job will run on
-      runs-on: self-hosted
+  # This workflow contains a single job that tests the playbook
+  playbook-test:
+    # The type of runner that the job will run on
+    runs-on: self-hosted
 
-      # Allow permissions for AWS auth
-      permissions:
-        id-token: write
-        contents: read
-        pull-requests: read
+    # Allow permissions for AWS auth
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
 
-      env:
-        ENABLE_DEBUG: ${{ vars.ENABLE_DEBUG }}
-        # Imported as a variable by terraform
-        TF_VAR_repository: ${{ github.event.repository.name }}
-        AWS_REGION: "us-east-1"
-        ANSIBLE_VERSION: ${{ vars.ANSIBLE_RUNNER_VERSION }}
-      defaults:
-        run:
-          shell: bash
-          working-directory: .github/workflows/github_linux_IaC
-          # working-directory: .github/workflows
+    env:
+      ENABLE_DEBUG: ${{ vars.ENABLE_DEBUG }}
+      # Imported as a variable by terraform
+      TF_VAR_repository: ${{ github.event.repository.name }}
+      AWS_REGION: "us-east-1"
+      ANSIBLE_VERSION: ${{ vars.ANSIBLE_RUNNER_VERSION }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: .github/workflows/github_linux_IaC
+        # working-directory: .github/workflows
 
-      steps:
+    steps:
 
-        - name: Git clone the lockdown repository to test
-          uses: actions/checkout@v4
-          with:
-            ref: ${{ github.event.pull_request.head.sha }}
+      - name: Git clone the lockdown repository to test
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
-        - name: If a variable for IAC_BRANCH is set use that branch
-          working-directory: .github/workflows
-          run: |
-            if [ ${{ vars.IAC_BRANCH }} != '' ]; then
-                echo "IAC_BRANCH=${{ vars.IAC_BRANCH }}" >> $GITHUB_ENV
-                echo "Pipeline using the following IAC branch ${{ vars.IAC_BRANCH }}"
-            else
-                echo IAC_BRANCH=main >> $GITHUB_ENV
-            fi
+      - name: If a variable for IAC_BRANCH is set use that branch
+        working-directory: .github/workflows
+        run: |
+          if [ ${{ vars.IAC_BRANCH }} != '' ]; then
+              echo "IAC_BRANCH=${{ vars.IAC_BRANCH }}" >> $GITHUB_ENV
+              echo "Pipeline using the following IAC branch ${{ vars.IAC_BRANCH }}"
+          else
+              echo IAC_BRANCH=main >> $GITHUB_ENV
+          fi
 
-        # Pull in terraform code for linux servers
-        - name: Clone GitHub IaC plan
-          uses: actions/checkout@v4
-          with:
-            repository: ansible-lockdown/github_linux_IaC
-            path: .github/workflows/github_linux_IaC
-            ref: ${{ env.IAC_BRANCH }}
+      # Pull in terraform code for linux servers
+      - name: Clone GitHub IaC plan
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: ansible-lockdown/github_linux_IaC
+          path: .github/workflows/github_linux_IaC
+          ref: ${{ env.IAC_BRANCH }}
 
-        # Uses dedicated restricted role and policy to enable this only for this task
-        # No credentials are part of github for AWS auth
-        - name: configure aws credentials
-          uses: aws-actions/configure-aws-credentials@main
-          with:
-            role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-            role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
-            aws-region: ${{ env.AWS_REGION }}
+      # Uses dedicated restricted role and policy to enable this only for this task
+      # No credentials are part of github for AWS auth
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
+          aws-region: ${{ env.AWS_REGION }}
 
-        - name: DEBUG - Show IaC files
-          if: env.ENABLE_DEBUG == 'true'
-          run: |
-            echo "OSVAR = $OSVAR"
-            echo "benchmark_type = $benchmark_type"
-            pwd
-          env:
-            # Imported from GitHub variables this is used to load the relevant OS.tfvars file
-            OSVAR: ${{ vars.OSVAR }}
-            benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+      - name: DEBUG - Show IaC files
+        if: env.ENABLE_DEBUG == 'true'
+        run: |
+          echo "OSVAR = $OSVAR"
+          echo "benchmark_type = $benchmark_type"
+          pwd
+        env:
+          # Imported from GitHub variables this is used to load the relevant OS.tfvars file
+          OSVAR: ${{ vars.OSVAR }}
+          benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
-        - name: Tofu init
-          id: init
-          run: tofu init
-          env:
-            # Imported from GitHub variables this is used to load the relevant OS.tfvars file
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+      - name: Tofu init
+        id: init
+        run: tofu init
+        env:
+          # Imported from GitHub variables this is used to load the relevant OS.tfvars file
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
-        - name: Tofu validate
-          id: validate
-          run: tofu validate
-          env:
-            # Imported from GitHub variables this is used to load the relevant OS.tfvars file
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+      - name: Tofu validate
+        id: validate
+        run: tofu validate
+        env:
+          # Imported from GitHub variables this is used to load the relevant OS.tfvars file
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
-        - name: Tofu apply
-          id: apply
-          env:
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
-            TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
-            TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
-          run: tofu apply -var-file "${OSVAR}.tfvars" --auto-approve -input=false
+      - name: Tofu apply
+        id: apply
+        env:
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+          TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
+          TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
+        run: tofu apply -var-file "${OSVAR}.tfvars" --auto-approve -input=false
 
 ## Debug Section
-        - name: DEBUG - Show Ansible hostfile
-          if: env.ENABLE_DEBUG == 'true'
-          run: cat hosts.yml
+      - name: DEBUG - Show Ansible hostfile
+        if: env.ENABLE_DEBUG == 'true'
+        run: cat hosts.yml
 
-  # Aws deployments taking a while to come up insert sleep or playbook fails
+# Aws deployments taking a while to come up insert sleep or playbook fails
 
-        - name: Sleep to allow system to come up
-          run: sleep ${{ vars.BUILD_SLEEPTIME }}
+      - name: Sleep to allow system to come up
+        run: sleep ${{ vars.BUILD_SLEEPTIME }}
 
-      # Run the Ansible playbook
-        - name: Run_Ansible_Playbook
-          env:
-            ANSIBLE_HOST_KEY_CHECKING: "false"
-            ANSIBLE_DEPRECATION_WARNINGS: "false"
-          run: |
-            /opt/ansible_${{ env.ANSIBLE_VERSION }}_venv/bin/ansible-playbook -i hosts.yml --private-key ~/.ssh/le_runner ../../../site.yml
+    # Run the Ansible playbook
+      - name: Run_Ansible_Playbook
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "false"
+          ANSIBLE_DEPRECATION_WARNINGS: "false"
+        run: |
+          /opt/ansible_${{ env.ANSIBLE_VERSION }}_venv/bin/ansible-playbook -i hosts.yml --private-key ~/.ssh/le_runner ../../../site.yml
 
-      # Remove test system - User secrets to keep if necessary
+    # Remove test system - User secrets to keep if necessary
 
-        - name: Tofu Destroy
-          if: always() && env.ENABLE_DEBUG == 'false'
-          env:
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
-            TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
-            TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
-          run: tofu destroy -var-file "${OSVAR}.tfvars" --auto-approve -input=false
+      - name: Tofu Destroy
+        if: always() && env.ENABLE_DEBUG == 'false'
+        env:
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+          TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
+          TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
+        run: tofu destroy -var-file "${OSVAR}.tfvars" --auto-approve -input=false

--- a/.github/workflows/export_badges_private.yml
+++ b/.github/workflows/export_badges_private.yml
@@ -2,18 +2,10 @@
 
 name: Export Private Repo Badges
 
-# Use different minute offsets with the same hourly pattern:
-# Repo Group Suggested Cron Expression Explanation
-# Group A 0 */6 * * * Starts at top of hour
-# Group B 10 */6 * * * Starts at 10 after
-# And So On
-
 on:
   push:
     branches:
       - latest
-  schedule:
-    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main_pipeline_validation.yml
+++ b/.github/workflows/main_pipeline_validation.yml
@@ -1,141 +1,141 @@
 ---
 
-  name: Main pipeline
+name: Main pipeline
 
-  on: # yamllint disable-line rule:truthy
-    pull_request_target:
-      types: [opened, reopened, synchronize]
-      branches:
-        - main
-        - latest
-      paths:
-        - '**.yml'
-        - '**.sh'
-        - '**.j2'
-        - '**.ps1'
-        - '**.cfg'
+on: # yamllint disable-line rule:truthy
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - latest
+    paths:
+      - '**.yml'
+      - '**.sh'
+      - '**.j2'
+      - '**.ps1'
+      - '**.cfg'
 
-  # Allow permissions for AWS auth
-  permissions:
-    id-token: write
-    contents: read
-    pull-requests: read
+# Allow permissions for AWS auth
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
 
-  # A workflow run is made up of one or more jobs
-  # that can run sequentially or in parallel
-  jobs:
-    # This workflow contains a single job that tests the playbook
-    playbook-test:
-      # The type of runner that the job will run on
-      runs-on: self-hosted
-      env:
-        ENABLE_DEBUG: ${{ vars.ENABLE_DEBUG }}
-        # Imported as a variable by terraform
-        TF_VAR_repository: ${{ github.event.repository.name }}
-        AWS_REGION : "us-east-1"
-        ANSIBLE_VERSION: ${{ vars.ANSIBLE_RUNNER_VERSION }}
-      defaults:
-        run:
-          shell: bash
-          working-directory: .github/workflows/github_linux_IaC
-          # working-directory: .github/workflows
+# A workflow run is made up of one or more jobs
+# that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job that tests the playbook
+  playbook-test:
+    # The type of runner that the job will run on
+    runs-on: self-hosted
+    env:
+      ENABLE_DEBUG: ${{ vars.ENABLE_DEBUG }}
+      # Imported as a variable by terraform
+      TF_VAR_repository: ${{ github.event.repository.name }}
+      AWS_REGION : "us-east-1"
+      ANSIBLE_VERSION: ${{ vars.ANSIBLE_RUNNER_VERSION }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: .github/workflows/github_linux_IaC
+        # working-directory: .github/workflows
 
-      steps:
+    steps:
 
-        - name: Git clone the lockdown repository to test
-          uses: actions/checkout@v4
-          with:
-            ref: ${{ github.event.pull_request.head.sha }}
+      - name: Git clone the lockdown repository to test
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
-        - name: If a variable for IAC_BRANCH is set use that branch
-          working-directory: .github/workflows
-          run: |
-            if [ ${{ vars.IAC_BRANCH }} != '' ]; then
-              echo "IAC_BRANCH=${{ vars.IAC_BRANCH }}" >> $GITHUB_ENV
-              echo "Pipeline using the following IAC branch ${{ vars.IAC_BRANCH }}"
-            else
-              echo IAC_BRANCH=main >> $GITHUB_ENV
-            fi
+      - name: If a variable for IAC_BRANCH is set use that branch
+        working-directory: .github/workflows
+        run: |
+          if [ ${{ vars.IAC_BRANCH }} != '' ]; then
+            echo "IAC_BRANCH=${{ vars.IAC_BRANCH }}" >> $GITHUB_ENV
+            echo "Pipeline using the following IAC branch ${{ vars.IAC_BRANCH }}"
+          else
+            echo IAC_BRANCH=main >> $GITHUB_ENV
+          fi
 
-        # Pull in terraform code for linux servers
-        - name: Clone GitHub IaC plan
-          uses: actions/checkout@v4
-          with:
-            repository: ansible-lockdown/github_linux_IaC
-            path: .github/workflows/github_linux_IaC
-            ref: ${{ env.IAC_BRANCH }}
+      # Pull in terraform code for linux servers
+      - name: Clone GitHub IaC plan
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: ansible-lockdown/github_linux_IaC
+          path: .github/workflows/github_linux_IaC
+          ref: ${{ env.IAC_BRANCH }}
 
-        # Uses dedicated restricted role and policy to enable this only for this task
-        # No credentials are part of github for AWS auth
-        - name: configure aws credentials
-          uses: aws-actions/configure-aws-credentials@main
-          with:
-            role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
-            role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
-            aws-region: ${{ env.AWS_REGION }}
+      # Uses dedicated restricted role and policy to enable this only for this task
+      # No credentials are part of github for AWS auth
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
+          aws-region: ${{ env.AWS_REGION }}
 
-        - name: DEBUG - Show IaC files
-          if: env.ENABLE_DEBUG == 'true'
-          run: |
-            echo "OSVAR = $OSVAR"
-            echo "benchmark_type = $benchmark_type"
-            pwd
-            ls
-          env:
-            # Imported from GitHub variables this is used to load the relevant OS.tfvars file
-            OSVAR: ${{ vars.OSVAR }}
-            benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+      - name: DEBUG - Show IaC files
+        if: env.ENABLE_DEBUG == 'true'
+        run: |
+          echo "OSVAR = $OSVAR"
+          echo "benchmark_type = $benchmark_type"
+          pwd
+          ls
+        env:
+          # Imported from GitHub variables this is used to load the relevant OS.tfvars file
+          OSVAR: ${{ vars.OSVAR }}
+          benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
-        - name: Tofu init
-          id: init
-          run: tofu init
-          env:
-            # Imported from GitHub variables this is used to load the relevant OS.tfvars file
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+      - name: Tofu init
+        id: init
+        run: tofu init
+        env:
+          # Imported from GitHub variables this is used to load the relevant OS.tfvars file
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
-        - name: Tofu validate
-          id: validate
-          run: tofu validate
-          env:
-            # Imported from GitHub variables this is used to load the relevant OS.tfvars file
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+      - name: Tofu validate
+        id: validate
+        run: tofu validate
+        env:
+          # Imported from GitHub variables this is used to load the relevant OS.tfvars file
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
-        - name: Tofu apply
-          id: apply
-          env:
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
-            TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
-            TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
-          run: tofu apply -var-file "${OSVAR}.tfvars" --auto-approve -input=false
+      - name: Tofu apply
+        id: apply
+        env:
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+          TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
+          TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
+        run: tofu apply -var-file "${OSVAR}.tfvars" --auto-approve -input=false
 
 ## Debug Section
-        - name: DEBUG - Show Ansible hostfile
-          if: env.ENABLE_DEBUG == 'true'
-          run: cat hosts.yml
+      - name: DEBUG - Show Ansible hostfile
+        if: env.ENABLE_DEBUG == 'true'
+        run: cat hosts.yml
 
-  # Aws deployments taking a while to come up insert sleep or playbook fails
+# Aws deployments taking a while to come up insert sleep or playbook fails
 
-        - name: Sleep to allow system to come up
-          run: sleep ${{ vars.BUILD_SLEEPTIME }}
+      - name: Sleep to allow system to come up
+        run: sleep ${{ vars.BUILD_SLEEPTIME }}
 
-      # Run the Ansible playbook
-        - name: Run_Ansible_Playbook
-          env:
-            ANSIBLE_HOST_KEY_CHECKING: "false"
-            ANSIBLE_DEPRECATION_WARNINGS: "false"
-          run: |
-            /opt/ansible_${{ env.ANSIBLE_VERSION }}_venv/bin/ansible-playbook -i hosts.yml --private-key ~/.ssh/le_runner ../../../site.yml
+    # Run the Ansible playbook
+      - name: Run_Ansible_Playbook
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "false"
+          ANSIBLE_DEPRECATION_WARNINGS: "false"
+        run: |
+          /opt/ansible_${{ env.ANSIBLE_VERSION }}_venv/bin/ansible-playbook -i hosts.yml --private-key ~/.ssh/le_runner ../../../site.yml
 
-      # Remove test system - User secrets to keep if necessary
+    # Remove test system - User secrets to keep if necessary
 
-        - name: Tofu Destroy
-          if: always() && env.ENABLE_DEBUG == 'false'
-          env:
-            OSVAR: ${{ vars.OSVAR }}
-            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
-            TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
-            TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
-          run: tofu destroy -var-file "${OSVAR}.tfvars" --auto-approve -input=false
+      - name: Tofu Destroy
+        if: always() && env.ENABLE_DEBUG == 'false'
+        env:
+          OSVAR: ${{ vars.OSVAR }}
+          TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+          TF_VAR_privsubnet_id: ${{ secrets.AWS_PRIVSUBNET_ID }}
+          TF_VAR_vpc_secgrp_id: ${{ secrets.AWS_VPC_SECGRP_ID }}
+        run: tofu destroy -var-file "${OSVAR}.tfvars" --auto-approve -input=false

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,23 @@ benchparse/
 *xccdf.xml
 *.retry
 
+# Secrets
+*.pem
+*.key
+*.p12
+*.pfx
+.vault_pass
+*.vault
+
+# Molecule artifacts
+.molecule/
+
 # GitHub Action/Workflow files
 .github/
 
 # pre-commit ansible-lint temp
 .ansible
+
+# QA tooling output (Repo_QA_Checker + cross_repo_validator)
+qa_report_*.md
+cross_repo_report_*.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,13 +42,13 @@ repos:
     name: Detect Secrets test
 
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.30.0
+  rev: v8.29.1
   hooks:
   - id: gitleaks
     name: Run Gitleaks test
 
 - repo: https://github.com/ansible-community/ansible-lint
-  rev: v26.4.0
+  rev: v25.11.0
   hooks:
   - id: ansible-lint
     name: Ansible-lint
@@ -67,7 +67,7 @@ repos:
     # - ansible-core>=2.10.1
 
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.38.0  # or higher tag
+  rev: v1.37.1  # or higher tag
   hooks:
   - id: yamllint
     name: Check YAML Lint

--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,5 @@
 ---
+
 extends: default
 ignore: |
     tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,134 @@
+# Ubuntu24STIG
+
+## Based on STIG v1r3
+
+## 1.3.0
+
+2026 May Updates
+
+QA hygiene sweep against V1R3 SCAP canonical benchmark (no rule additions/removals - V1R3 scope preserved).
+
+- meta/main.yml: bump min_ansible_version 2.12.1 -> 2.16.1, set author to Ansible-Lockdown Team, append company suffix to MindPoint Group - A Tyto Athene Company, drop duplicate ubuntuserver galaxy tag
+- vars/main.yml: bump min_ansible_version 2.12.1 -> 2.16.1
+- LICENSE: fix casing Mindpoint -> MindPoint
+- README.md: replace 21 occurrences of UBTU24-STIG with UBUNTU24-STIG so badge and pipeline URLs resolve correctly
+- .gitignore: add secret patterns (*.pem *.key *.p12 *.pfx .vault_pass *.vault) and .molecule/ artifact directory
+- CHANGELOG.md: renamed from Changelog.md to match Lockdown convention (macOS case-insensitive FS aware rename)
+- tasks/main.yml: broaden container detection to also match community.docker.docker connection plugin; convert two absolute-notation file modes to relative ('u=rwx,go=rx' -> 'go-w', 'u-x,go=r' -> 'go-wx')
+- tasks/Cat2/UBTU24-70xxxx.yml: UBTU-24-700040 journalctl mode 'u=rwx,g=r,o-rwx' -> 'g-wx,o-rwx' (relative notation)
+- tasks/Cat2/UBTU24-10xxxx.yml: UBTU-24-100120 audit step removed shell redirect from ansible.builtin.command (silent failure risk on dash); UBTU-24-100040 title double-space typo collapsed
+- tasks/prelim.yml: PRELIM | AUDIT | Discover wireless adapter - reorder register: after changed_when/failed_when
+- handlers/main.yml: Audit_immutable_fact notify case fix (change_requires_reboot -> Change_requires_reboot) - case-sensitive handler match was silently dropping the auditd-immutable reboot flag
+- .github/workflows/export_badges_public.yml: deleted from private repo (public mirror has its own copy)
+
+CAT 1 - SV-* tag rN-suffix alignment with V1R3 SCAP (rule numbers unchanged, only revision suffix corrected):
+- UBTU-24-102000 - SV-270675r1117265 -> SV-270675r1137691
+- UBTU-24-600030 - SV-270744r1117272 -> SV-270744r1137699
+- UBTU-24-700400 - SV-278917r1135000 -> SV-278917r1155246
+
+CAT 2 - SV-* tag rN-suffix alignment with V1R3 SCAP:
+- UBTU-24-100860 - SV-270671r1067118 -> SV-270671r1155244
+- UBTU-24-102010 - SV-270676r1068360 -> SV-270676r1155245
+- UBTU-24-200270 - SV-274870r1107304 -> SV-274870r1155243
+- UBTU-24-600070 - SV-270746r1101769 -> SV-270746r1155242
+
+CAT 3 - SV-* tag rN-suffix alignment with V1R3 SCAP:
+- UBTU-24-400340 - SV-270734r1066691 -> SV-270734r1155240
+- UBTU-24-600140 - SV-270749r1117267 -> SV-270749r1137695
+
+2026 Feb Updates
+
+- QA fixes: grammar corrections (README.md, defaults/main.yml)
+- Removed unused variables: audit_run_heavy_tests, discover_int_uid, ubtu24stig_legacy_boot
+- Added missing variable definition: ubtu24stig_time_pool
+- Fixed incorrect variable reference: ubtu24stig_sudo_group_required to ubtu24stig_sudo_group_users
+- Standardized register variable names in prelim.yml to use prelim_ prefix
+
+2026 Jan Updates
+
+- Added extra options and explanation for audit component
+- Linting: removed deprecated parseable option from ansible-lint config
+- Improved logic for 300020. Added sudoers_exclude to logic.
+
+CAT 1
+- UBTU-24-300038 - ruleid updated
+- UBTU-24-700400 - moved from CAT2 rules id updates
+
+CAT 2
+- UBTU-24-100110 - ruleid updated
+- UBTU-24-100840 - ruleid updated
+- UBTU-24-200090 - ruleid updated
+- UBTU-24-300039 - ruleid updated
+- UBTU-24-700010 - ruleid updated and exclusions
+- UBTU-24-901230 - ruleid - audit pkg list updated to remove audisp
+- UBTU-24-901240 - ruleid - audit pkg list updated to remove audisp
+- UBTU-24-901250 - ruleid - audit pkg list updated to remove audisp
+- UBTU-24-909890 - rule moved from 901890 - ruleid updated
+
+CAT 3
+- UBTU-24-900950 - fixed conditional logic
+
+## Based on STIG v1r2
+
+## 1.2.0
+
+CAT 1
+- UBTU-24-300025 - Updated
+
+CAT 2
+- UBTU-24-200020 - ruleid and new steps
+- UBTU-24-200040 - requirement change and new tasks
+- UBTU-24-200041 - new requirement
+- UBTU-24-200042 - new requirement
+- UBTU-24-200043 - new requirement
+- UBTU-24-200270 - new requirement
+- UBTU-24-300006 - updated search path - ruleid
+- UBTU-24-300007 - updated search path - ruleid
+- UBTU-24-300008 - updated search path - ruleid
+- UBTU-24-300009 - updated search path - ruleid
+- UBTU-24-300019 - new requirement
+- UBTU-24-300020 - new requirement
+- UBTU-24-300021 - updated
+- UBTU-24-400220 - ruleid
+
+CAT 3
+- UBTU-24-200000 - ruleid
+
+### Post-QA continuation (May 2026)
+
+Follow-up work after the initial QA hygiene sweep above, surfaced by the molecule converge cycle and a second-pass review of the audit-paired repo.
+
+Role infrastructure:
+- molecule/default/: new scenario added. Uses `geerlingguy/docker-ubuntu2404-ansible:latest` (multi-arch, no Rosetta needed on Apple Silicon), explicit `roles_path` so include_role resolves, `_molecule_role_name` (avoids reserved `role_name`), `setup_audit: true` / `run_audit: true` in host_vars. Prepare playbook installs full STIG package set + `python3-apt`, creates `/run/sshd`, `/etc/sysctl.d`, `/etc/ssh/sshd_config.d`. Converge passes `failed=0`.
+
+tasks/check_prereqs.yml:
+- Was unconditionally installing `libselinux-python3` (RHEL-template leakage). Replaced with conditional `python3-apt` installation — the actual apt-module prereq on minimal containers.
+
+README.md Technical Dependencies section:
+- `Python3.8` -> `Python 3.10+ (Ubuntu 24.04 ships 3.12)`, `Ansible 2.12+` -> `Ansible 2.16.1+` (matches meta/main.yml), removed `python-def` (non-existent package), `libselinux-python` -> `python3-apt`.
+
+vars/is_container.yml — comprehensive population:
+- Initial sweep based on V1R3 SCAP title categorisation (auditd, FIPS, GRUB/kernel/sysctl/modprobe, AppArmor, firewall, time sync, journal_upload).
+- Iterative additions surfaced by molecule converge failures: UBTU-24-300041, UBTU-24-600190 (TCP syncookies sysctl), UBTU-24-600200, UBTU-24-600230 (wireless modprobe), UBTU-24-100450, UBTU-24-900920/950/960/980 (manual-only auditd not in V1R3 SCAP), UBTU-24-100660 (apparmor-tagged SSSD).
+- Environment-impossible section added: UBTU-24-400340 (SSSD), UBTU-24-600060 (DOD PKI CAs), UBTU-24-600090 (disk encryption), UBTU-24-700300 (CPU NX bit).
+- Total: 76 -> 86 -> 90 disables.
+
+Idempotency fixes (molecule converge previously reported changed=7 on first run, changed=6 on second run):
+- tasks/prelim.yml — PRELIM apt update: added `changed_when: false`; `cache_valid_time: 7200` is read-only metadata refresh.
+- tasks/pre_remediation_audit.yml & tasks/post_remediation_audit.yml — run_audit.sh shell calls had `changed_when: true` forcing 'changed' on every run. Audit is read-only; switched to `changed_when: false`.
+
+Known by-design idempotency violation not fixed:
+- templates/etc/ansible/compliance_facts.j2 renders `Benchmark_run_date` and `audit_run_date` timestamps inline, so the rendered file legitimately changes every run. Splitting into stable + volatile fact files is left for a future refactor.
+
+Wrong-toggle gate fix (Phase 5 verification surfaced):
+- tasks/Cat2/UBTU24-10xxxx.yml UBTU-24-100650 (SSSD package install, SV-270662) — task was gated by `when: - ubtu24stig_100600` (the sibling rule's toggle, copy-paste artifact) instead of its own `ubtu24stig_100650`. Effect: the `ubtu24stig_100650` toggle was dead and users disabling rule 100650 via its own toggle had no effect (they had to disable the unrelated 100600 toggle, which also disables a different rule). One-line fix: changed `ubtu24stig_100600` -> `ubtu24stig_100650` in the when: clause around line 336.
+
+Dead toggle removed:
+- `ubtu24stig_900500` removed from `defaults/main.yml` and `templates/ansible_vars_goss.yml.j2`. Not in V1R3 SCAP, not in V1R5 manual XCCDF — pure placeholder with no corresponding task or audit test. Paired audit-repo removal in vars/STIG.yml.
+
+## Based on STIG v1r1
+
+pre-commit updates
+### 1.0.0
+
+### Initial

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,27 +1,26 @@
-# Contributing to Ansible-lockdown Projects
+Contributing to Ansible-Lockdown Projects
+========================================
 
-## Rules
-
+Rules
+-----
 1) All commits must be GPG signed (details in Signing section)
-2) All commits must have Signed-off-by in the commit message (details in Signing section). e.g.
-
-    Signed-off-by: Joan Doe <joan.doe@email.com>
-
+2) All commits must have Signed-off-by (Signed-off-by: Joan Doe <joan.doe@email.com>) in the commit message (details in Signing section)
 3) All work is done in your own branch
 4) All pull requests go into the devel branch. There are automated checks for signed commits, signoff in commit message, and functional testing)
 5) Be open and nice to each other
 
-## Workflow
-
+Workflow
+--------
 - Your work is done in your own individual branch. Make sure to to Signed-off and GPG sign all commits you intend to merge
 - All community Pull Requests are into the devel branch. There are automated checks for GPG signed, Signed-off in commits, and functional tests before being approved. If your pull request comes in from outside of our repo, the pull request will go into a staging branch. There is info needed from our repo for our CI/CD testing.
 - Once your changes are merged and a more detailed review is complete, an authorized member will merge your changes into the main branch for a new release
 
-## Signing your contribution
+Signing your contribution
+-------------------------
 
 We've chosen to use the Developer's Certificate of Origin (DCO) method
 that is employed by the Linux Kernel Project, which provides a simple
-way to contribute to MindPoint Group projects.
+way to contribute to Ansible-Lockdown projects.
 
 The process is to certify the below DCO 1.1 text
 ::
@@ -62,10 +61,6 @@ following text in your contribution commit message:
 
 ::
 
-## Helpful links
-
 This message can be entered manually, or if you have configured git
 with the correct `user.name` and `user.email`, you can use the `-s`
 option to `git commit` to automatically include the signoff message.
-
-For help or understanding how to achieve these requirements good article explaining more. [Signedoff and signing commits](https://dev.to/janderssonse/git-signoff-and-signing-like-a-champ-41f3)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,0 @@
-# Ubuntu24STIG
-
-## Based on STIG v1r1
-
-### 1.0.0
-
-### Initial

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-# MIT License
+MIT License
 
-Copyright (c) 2025 Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
+Copyright (c) 2026 MindPoint Group - A Tyto Athene Company / Ansible Lockdown
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 ## Configure a UBUNTU24 based system to be complaint with DISA STIG
 
-This role is based on UBUNTU 24 DISA STIG: [Version 1, Rel 1 released on Februaury 21, 2025](https://dl.dod.cyber.mil/wp-content/uploads/stigs/U_UBUNTU_24_V1R1_STIG.zip).
+This role is based on UBUNTU 24 DISA STIG: [Version 1, Rel 3 released on Oct 01, 2025](https://dl.dod.cyber.mil/wp-content/uploads/stigs/U_UBUNTU_24_V1R3_STIG.zip).
 
 ---
 
 ## Public Repository 📣
 
 ![Org Stars](https://img.shields.io/github/stars/ansible-lockdown?label=Org%20Stars&style=social)
-![Stars](https://img.shields.io/github/stars/ansible-lockdown/UBTU24-STIG?label=Repo%20Stars&style=social)
-![Forks](https://img.shields.io/github/forks/ansible-lockdown/UBTU24-STIG?style=social)
+![Stars](https://img.shields.io/github/stars/ansible-lockdown/UBUNTU24-STIG?label=Repo%20Stars&style=social)
+![Forks](https://img.shields.io/github/forks/ansible-lockdown/UBUNTU24-STIG?style=social)
 ![Followers](https://img.shields.io/github/followers/ansible-lockdown?style=social)
-[![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/AnsibleLockdown.svg?style=social&label=Follow%20%40AnsibleLockdown)](https://twitter.com/AnsibleLockdown)
-![Discord Badge](https://img.shields.io/discord/925818806838919249?logo=discord)
+[![X URL](https://img.shields.io/twitter/url/https/x.com/AnsibleLockdown.svg?style=social&label=Follow%20%40AnsibleLockdown)](https://x.com/AnsibleLockdown)
+![Discord Badge](https://img.shields.io/discord/925818806838919229?logo=discord)
 
-![License](https://img.shields.io/github/license/ansible-lockdown/UBTU24-STIG?label=License)
+![License](https://img.shields.io/github/license/ansible-lockdown/UBUNTU24-STIG?label=License)
 
 ## Lint & Pre-Commit Tools 🔧
 
@@ -25,40 +25,40 @@ This role is based on UBUNTU 24 DISA STIG: [Version 1, Rel 1 released on Februau
 ## Community Release Information 📂
 
 ![Release Branch](https://img.shields.io/badge/Release%20Branch-Main-brightgreen)
-![Release Tag](https://img.shields.io/github/v/tag/ansible-lockdown/UBTU24-STIG?label=Release%20Tag&&color=success)
-![Main Release Date](https://img.shields.io/github/release-date/ansible-lockdown/UBTU24-STIG?label=Release%20Date)
-![Benchmark Version Main](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/UBTU24-STIG/benchmark-version-main.json)
-![Benchmark Version Devel](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/UBTU24-STIG/benchmark-version-devel.json)
+![Release Tag](https://img.shields.io/github/v/tag/ansible-lockdown/UBUNTU24-STIG?label=Release%20Tag&&color=success)
+![Main Release Date](https://img.shields.io/github/release-date/ansible-lockdown/UBUNTU24-STIG?label=Release%20Date)
+![Benchmark Version Main](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/UBUNTU24-STIG/benchmark-version-main.json)
+![Benchmark Version Devel](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/UBUNTU24-STIG/benchmark-version-devel.json)
 
-[![Main Pipeline Status](https://github.com/ansible-lockdown/UBTU24-STIG/actions/workflows/main_pipeline_validation.yml/badge.svg?)](https://github.com/ansible-lockdown/UBTU24-STIG/actions/workflows/main_pipeline_validation.yml)
+[![Main Pipeline Status](https://github.com/ansible-lockdown/UBUNTU24-STIG/actions/workflows/main_pipeline_validation.yml/badge.svg?)](https://github.com/ansible-lockdown/UBUNTU24-STIG/actions/workflows/main_pipeline_validation.yml)
 
-[![Devel Pipeline Status](https://github.com/ansible-lockdown/UBTU24-STIG/actions/workflows/devel_pipeline_validation.yml/badge.svg?)](https://github.com/ansible-lockdown/UBTU24-STIG/actions/workflows/devel_pipeline_validation.yml)
+[![Devel Pipeline Status](https://github.com/ansible-lockdown/UBUNTU24-STIG/actions/workflows/devel_pipeline_validation.yml/badge.svg?)](https://github.com/ansible-lockdown/UBUNTU24-STIG/actions/workflows/devel_pipeline_validation.yml)
 
 
-![Devel Commits](https://img.shields.io/github/commit-activity/m/ansible-lockdown/UBTU24-STIG/devel?color=dark%20green&label=Devel%20Branch%20Commits)
-![Open Issues](https://img.shields.io/github/issues-raw/ansible-lockdown/UBTU24-STIG?label=Open%20Issues)
-![Closed Issues](https://img.shields.io/github/issues-closed-raw/ansible-lockdown/UBTU24-STIG?label=Closed%20Issues&&color=success)
-![Pull Requests](https://img.shields.io/github/issues-pr/ansible-lockdown/UBTU24-STIG?label=Pull%20Requests)
+![Devel Commits](https://img.shields.io/github/commit-activity/m/ansible-lockdown/UBUNTU24-STIG/devel?color=dark%20green&label=Devel%20Branch%20Commits)
+![Open Issues](https://img.shields.io/github/issues-raw/ansible-lockdown/UBUNTU24-STIG?label=Open%20Issues)
+![Closed Issues](https://img.shields.io/github/issues-closed-raw/ansible-lockdown/UBUNTU24-STIG?label=Closed%20Issues&&color=success)
+![Pull Requests](https://img.shields.io/github/issues-pr/ansible-lockdown/UBUNTU24-STIG?label=Pull%20Requests)
 
 ---
 
 ## Subscriber Release Information 🔐
 
-![Private Release Branch](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBTU24-STIG/release-branch.json)
-![Private Benchmark Version](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBTU24-STIG/benchmark-version.json)
+![Private Release Branch](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-STIG/release-branch.json)
+![Private Benchmark Version](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-STIG/benchmark-version.json)
 
-[![Private Remediate Pipeline](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBTU24-STIG/remediate.json)](https://github.com/ansible-lockdown/Private-UBTU24-STIG/actions/workflows/main_pipeline_validation.yml)
+[![Private Remediate Pipeline](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-STIG/remediate.json)](https://github.com/ansible-lockdown/Private-UBUNTU24-STIG/actions/workflows/main_pipeline_validation.yml)
 
-![Private Pull Requests](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBTU24-STIG/prs.json)
-![Private Closed Issues](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBTU24-STIG/issues-closed.json)
+![Private Pull Requests](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-STIG/prs.json)
+![Private Closed Issues](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-STIG/issues-closed.json)
 
 ---
 
 ## Looking for support? 🤝
 
-[Lockdown Enterprise](https://www.lockdownenterprise.com#GH_AL_UBTU24-STIG)
+[Lockdown Enterprise](https://www.lockdownenterprise.com#GH_AL_UBUNTU24-STIG)
 
-[Ansible support](https://www.mindpointgroup.com/cybersecurity-products/ansible-counselor#GH_AL_UBTU24-STIG)
+[Ansible support](https://www.mindpointgroup.com/cybersecurity-products/ansible-counselor#GH_AL_UBUNTU24-STIG)
 
 ### Community 💬
 
@@ -93,7 +93,7 @@ Further details can be seen in the [Changelog](./ChangeLog.md)
 
 ## Matching a security Level for STIG
 
-It is possible to to only run category 1, 2 or 3 controls for STIG.
+It is possible to only run category 1, 2 or 3 controls for STIG.
 This is managed using tags:
 
 - CAT1
@@ -122,14 +122,13 @@ ubtu24stig_cat3: true
 
 **Technical Dependencies:**
 
-Ubuntu24
+Ubuntu 24.04 LTS
 
 - Access to download or add the goss binary and content to the system if using auditing
 (other options are available on how to get the content to the system.)
-- Python3.8
-- Ansible 2.12+
-- python-def
-- libselinux-python
+- Python 3.10+ (Ubuntu 24.04 ships 3.12)
+- Ansible 2.16.1+
+- python3-apt (for the `apt` module — pre-installed on stock Ubuntu cloud images)
 
 ---
 
@@ -142,7 +141,7 @@ This is a much quicker, very lightweight, checking (where possible) config compl
 A new form of auditing has been developed, by using a small (12MB) go binary called [goss](https://github.com/goss-org/goss) along with the relevant configurations to check. Without the need for infrastructure or other tooling.
 This audit will not only check the config has the correct setting but aims to capture if it is running with that configuration also trying to remove [false positives](https://www.mindpointgroup.com/blog/is-compliance-scanning-still-relevant/) in the process.
 
-Refer to [UBTU24-STIG-Audit](https://github.com/ansible-lockdown/UBTU24-STIG-Audit).
+Refer to [UBUNTU24-STIG-Audit](https://github.com/ansible-lockdown/UBUNTU24-STIG-Audit).
 
 ## Example Audit Summary
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## metadata for Audit benchmark
-benchmark_version: 'v1.1.0'
+benchmark_version: 'v1.3.0'
 
 ## Benchmark name used by auditing control role
 # The audit variable found at the base
@@ -60,6 +60,10 @@ system_is_ec2: false
 # Whether to purge apt pages when removed
 ubtu24stig_purge_apt: false
 
+## Apt/dpkg lock timeout (seconds)
+# Wait time for apt/dpkg frontend lock to clear before failing package tasks.
+ubtu24stig_apt_lock_timeout: 180
+
 # Create managed not custom local_facts files
 create_benchmark_facts: true
 ansible_facts_path: /etc/ansible/facts.d
@@ -79,68 +83,106 @@ min_int_uid: 1000
 # been set to `true`.
 max_int_uid: 65533
 
-###
-### Settings for associated Audit role using Goss
-###
+########## BEGIN ##########
+### Audit role Settings ###
+###########################
+## Goss the audit binary
+## is required to be available
+## on the remote host
+## Other settings found vars/audit.yml
 
-###########################################
-### Goss is required on the remote host ###
-### vars/audit.yml for other settings  ###
-
-# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding Goss binary to system)
+# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
 setup_audit: false
 
 # enable audits to run - this runs the audit and get the latest content
 run_audit: false
-# Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
-audit_run_heavy_tests: true
+
+# Ability to limit the number of concurrent processes used by goss (default 50)
+audit_max_concurrent: 50
 
 ## Only run Audit do not remediate
 audit_only: false
 
 #############################
+## If using audit content ###
+## e.g. lockdown dashboard ##
+#############################
+## Ability to collect and take audit files moving to a centralised location
 
-# How to retrieve audit binary
-# Options are copy or download - detailed settings at the bottom of this file
-# you will need to access to either github or the file already downloaded
+## This enables the collection of the files from the host
+fetch_audit_output: false
+
+## Method of getting,uploading the summary files
+## Ensure access and permissions are available for these to occur.
+## options are
+## fetch - fetches from server and moves to location on the ansible controller (could be a mount point available to controller)
+## copy - copies file to a location available to the managed node
+audit_output_collection_method: fetch
+
+## Location to put the audit files
+audit_output_destination: /opt/audit_summaries/
+
+############################
+### Audit binary options ###
+############################
+## How to retrieve audit binary
+## Options are copy or download - detailed settings at the bottom of this file
+## you will need to access to either github or the file already downloaded
 get_audit_binary_method: download
+
+## If downloading the audit binary(goss)
+## Useful when self hosting the content
+## This enables the ability to not check ssl certificates using the get_url module
+audit_bin_validate_certs: true
+
+## Added the following options will default to not pass options
+## Please utilize a vault or alternative way to ensure encryption of details
+#
+# audit_bin_url_username:
+# audit_bin_url_password:
 
 ## if get_audit_binary_method - copy the following needs to be updated for your environment
 ## it is expected that it will be copied from somewhere accessible to the control node
 ## e.g copy from ansible control node to remote host
 audit_bin_copy_location: /some/accessible/path
 
-# how to get audit files onto host options
-# options are git/copy/archive/get_url other e.g. if you wish to run from already downloaded conf
+#############################
+### Audit Content options ###
+#############################
+## how to get audit files onto host options
+## options are git/copy/archive/get_url other e.g. if you wish to run from already downloaded conf
 audit_content: git
 
-# If using either archive, copy, get_url:
+## If using authenticated git
+## Populate the required fields below
+## Location of the key file used to authenticate
+## Please ensure that the key does not have a password set
+## Best practice it to use some form of vault for this information
+#
+# audit_content_key_file: 'somepath to key file'
+
+## If using self hosted repository
+## the url will need to be updated with
+## Can pass user/pass in url - please use vault options
+#
+# self_hosted_audit_repo: https://USER:PASS@gitrepo.com/audit_reponame
+
+## If using either archive, copy, get_url:
 ## Note will work with .tar files - zip will require extra configuration
-### If using get_url this is expecting github url in tar.gz format e.g.(Note the benchmark version)
-### https://github.com/ansible-lockdown/UBUNTU24-STIG-Audit/archive/refs/heads/benchmark-v1.0.0.tar.gz
+## If using get_url this is expecting github url in tar.gz format e.g.
+## https://github.com/ansible-lockdown/{OSTYPE}-{BENCMHARK_TYPE}-Audit/archive/refs/heads/benchmark-{{ benchmark_version }}.tar.gz
 audit_conf_source: "some path or url to copy from"
 
-# Destination for the audit content to be placed on managed node
-# note may not need full path e.g. /opt with the directory being the {{ benchmark }}-Audit directory
+## Destination for the audit content to be placed on managed node
+## note may not need full path e.g. /opt with the directory being the {{ benchmark }}-Audit directory
 audit_conf_dest: "/opt"
 
-# Where the audit logs are stored
+## Where the audit logs are stored
 audit_log_dir: '/opt'
 
-# Method of getting,uploading the summary files
-## Enable the collection of audit files
-fetch_audit_output: false
-## Ensure access and permissions are available for these to occur.
-## options are
-# fetch - fetches from server and moves to location on the ansible controller (could be a mount point available to controller)
-# copy - copies file to a location available to the managed node
-audit_output_collection_method: fetch
-
-# Location to put the audit files
-audit_output_destination: /opt/audit_summaries/
-
-### Goss Settings ##
-####### END ########
+########### END ###########
+### Audit role Settings ###
+###########################
 
 #### CAT 1
 
@@ -158,6 +200,7 @@ ubtu24stig_300031: true
 ubtu24stig_400370: true
 ubtu24stig_600030: true
 ubtu24stig_600130: true
+ubtu24stig_700400: true
 
 #### CAT 2
 ## 10XXXX
@@ -188,10 +231,14 @@ ubtu24stig_102010: true
 ## 20XXXX
 ubtu24stig_200020: true
 ubtu24stig_200040: true
+ubtu24stig_200041: true
+ubtu24stig_200042: true
+ubtu24stig_200043: true
 ubtu24stig_200060: true
 ubtu24stig_200090: true
 ubtu24stig_200250: true
 ubtu24stig_200260: true
+ubtu24stig_200270: true
 ubtu24stig_200280: true
 ubtu24stig_200290: true
 ubtu24stig_200300: true
@@ -214,6 +261,8 @@ ubtu24stig_300012: true
 ubtu24stig_300013: true
 ubtu24stig_300014: true
 ubtu24stig_300016: true
+ubtu24stig_300019: true
+ubtu24stig_300020: true
 ubtu24stig_300021: true
 ubtu24stig_300023: true
 ubtu24stig_300029: true
@@ -275,7 +324,6 @@ ubtu24stig_700150: true
 ubtu24stig_700300: true
 ubtu24stig_700310: true
 ubtu24stig_700320: true
-ubtu24stig_700400: true
 
 ## 900XXX
 ubtu24stig_900040: true
@@ -310,7 +358,6 @@ ubtu24stig_900320: true
 ubtu24stig_900330: true
 ubtu24stig_900340: true
 ubtu24stig_900350: true
-ubtu24stig_900500: true
 ubtu24stig_900510: true
 ubtu24stig_900520: true
 ubtu24stig_900540: true
@@ -332,10 +379,10 @@ ubtu24stig_901300: true
 ubtu24stig_901310: true
 ubtu24stig_901350: true
 ubtu24stig_901380: true
-ubtu24stig_901890: true
 
 ## 909XXX
 ubtu24stig_909000: true
+ubtu24stig_909890: true
 
 #### CAT 3
 ubtu24stig_100010: true
@@ -396,7 +443,12 @@ ubtu24stig_maxlogins: 10
 
 ### 2000xx - Gnome Desktop
 ### Graphical/Gnome interface required
-ubtu24stig_gui: "{{ ubtu24_gnome_present.stat.exists | default(false) }}"
+ubtu24stig_gui: "{{ prelim_gnome_present.stat.exists | default(false) }}"
+
+### 200020 - screensaver
+# ubtu24stig_screen_idle_delay is the amount of time in seconds before screen locks
+# To be STIG compliant this value must be 900 seconds (10 minutes) or less
+ubtu24stig_screen_idle_delay: 600
 
 ## 200260
 # Number of days account is active before disabled
@@ -457,6 +509,13 @@ ubtu24stig_sshd_config_file: /etc/ssh/sshd_config
 # faildelay
 ubtu24stig_faildelay: 4000000  # 4000000 is the minimum value = 4 seconds
 
+# 300020 and 300021
+## Users to exclude from NOPASSWD removal
+# This will leave NOPASSWD intact for these users
+ubtu24stig_sudoers_exclude_nopasswd_list:
+  - ec2-user
+  - vagrant
+  - ubuntu
 ##############
 ### 40XXXX ###
 ##############
@@ -489,7 +548,15 @@ ubtu24stig_time_synchronization_servers:
   - 'tick.usno.navy.mil'
   - 'tock.usno.navy.mil'
   - 'ntp2.usno.navy.mil'
-ubtu24stig_chrony_server_options: "iburst maxpoll 16"  # Max Settings is maxpoll 16
+ubtu24stig_chrony_server_options: "iburst maxpoll 16"  # Max setting is maxpoll 16
+
+ubtu24stig_time_pool:
+  - name: 'tick.usno.navy.mil'
+    options: "iburst maxpoll 16"
+  - name: 'tock.usno.navy.mil'
+    options: "iburst maxpoll 16"
+  - name: 'ntp2.usno.navy.mil'
+    options: "iburst maxpoll 16"
 
 # 600130
 ## Users to be added to the sudo group
@@ -523,5 +590,4 @@ ubtu24stig_audit_tools:
   - /sbin/ausearch
   - /sbin/autrace
   - /sbin/auditd
-  - /sbin/audispd-zos-remote
   - /sbin/augenrules

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -114,7 +114,7 @@
     msg: "Reboot required for auditd to apply new rules as immutable set"
   changed_when: false
   failed_when: false
-  notify: change_requires_reboot
+  notify: Change_requires_reboot
 
 - name: Restart_auditd
   ansible.builtin.command: service auditd restart  # noqa: command-instead-of-module

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,13 +1,13 @@
 ---
 
 galaxy_info:
-  author: "Mark Bolwell"
+  author: "Ansible-Lockdown Team"
   description: "Apply the Ubuntu24 STIG using ansible"
-  company: "MindPoint Group"
+  company: "MindPoint Group - A Tyto Athene Company"
   license: MIT
   role_name: ubuntu24_stig
   namespace: mindpointgroup
-  min_ansible_version: 2.12.1
+  min_ansible_version: 2.16.1
   platforms:
     - name: Ubuntu
       versions:
@@ -16,7 +16,6 @@ galaxy_info:
     - ubuntu
     - ubuntu24
     - ubuntu2404
-    - ubuntuserver
     - ubuntuserver
     - ubuntusecurity
     - ubuntuhardening

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,61 @@
+---
+
+# Molecule converge playbook for UB24-STIG V1R3.
+# Container-incompatible rules are handled by vars/is_container.yml (loaded
+# automatically by tasks/main.yml when the docker connection is detected).
+# Anything here is purely test-scaffolding the role needs to bootstrap inside
+# a container.
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+  vars:
+    # `role_name` is reserved in Ansible — use underscore-prefixed local name.
+    _molecule_role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    ansible_user: root
+
+    # Test-scaffolding: pretend we already gathered the prerequisites
+    ubtu24stig_skip_for_test: true
+    setup_audit: true
+    run_audit: true
+
+    # The role's bootloader assertion runs only on non-container hosts, but
+    # set both anyway so any stray check passes.
+    ubtu24stig_set_bootloader_password: false
+    ubtu24stig_bootloader_password_hash: "grub.pbkdf2.sha512.10000.DEADBEEF.DEADBEEF"  # pragma: allowlist secret
+
+    # Reboot is meaningless inside a container.
+    change_requires_reboot: false
+
+  pre_tasks:
+    - name: Set a real root password (some STIG rules verify /etc/shadow state)
+      ansible.builtin.shell:
+        cmd: |
+          set -e
+          current=$(awk -F: 'BEGIN{p=""} $1=="root"{p=$2} END{print p}' /etc/shadow)
+          if [ -z "$current" ] || [ "$current" = "!" ] || [ "$current" = "!!" ] || [ "$current" = "*" ]; then
+            echo 'root:MoleculeTest123!' | chpasswd
+            echo "SET"
+          else
+            echo "SKIP"
+          fi
+        executable: /bin/bash
+      register: _root_pw_setup
+      changed_when: '"SET" in _root_pw_setup.stdout'
+
+    - name: Create /etc/default/grub stub
+      ansible.builtin.copy:
+        dest: /etc/default/grub
+        content: |
+          # Stub grub config for molecule container testing
+          GRUB_DEFAULT=0
+          GRUB_TIMEOUT=5
+          GRUB_CMDLINE_LINUX_DEFAULT=""
+          GRUB_CMDLINE_LINUX=""
+        mode: '0644'
+
+  tasks:
+    - name: "Include role"
+      ansible.builtin.include_role:
+        name: "{{ _molecule_role_name }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,44 @@
+---
+# Molecule configuration
+# https://molecule.readthedocs.io/en/latest/
+
+driver:
+  name: docker
+
+platforms:
+  - name: ubuntu2404
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    # geerlingguy/docker-ubuntu2404-ansible is multi-arch (amd64+arm64) —
+    # no platform pin needed, Docker picks native (faster than Rosetta on
+    # Apple Silicon). Pin to linux/amd64 only if reproducing CI behavior.
+    pre_build_image: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    command: "/lib/systemd/systemd"
+    cgroupns_mode: host
+    tmpfs:
+      - /run
+      - /tmp
+    capabilities:
+      - SYS_ADMIN
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      callbacks_enabled: profile_tasks, timer
+      # Resolve the role itself by name (basename of MOLECULE_PROJECT_DIRECTORY).
+      # Ansible default search path doesn't include the role's parent dir, so
+      # include_role: name: Private-UBUNTU24-STIG fails without this hint.
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/..:${MOLECULE_PROJECT_DIRECTORY}/molecule/default/roles"
+  inventory:
+    host_vars:
+      ubuntu2404:
+        ansible_become: false
+        setup_audit: true
+        run_audit: true
+
+verifier:
+  name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,53 @@
+---
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install packages needed for STIG hardening in container
+      ansible.builtin.apt:
+        name:
+          - openssh-server
+          - libpam-pwquality
+          - libpam-modules
+          - sudo
+          - acl
+          - kmod
+          - cron
+          - chrony
+          - rsyslog
+          - aide
+          - aide-common
+          - logrotate
+          - apparmor
+          - apparmor-utils
+          - ufw
+          - nftables
+          - auditd
+          - autofs
+          - python3-apt
+        state: present
+        update_cache: true
+
+    - name: Create privilege-separation and config directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - /run/sshd
+        - /etc/sysctl.d
+        - /etc/ssh/sshd_config.d
+
+    - name: Start and enable cron
+      ansible.builtin.systemd:
+        name: cron
+        state: started
+        enabled: true
+
+    - name: Start and enable rsyslog
+      ansible.builtin.systemd:
+        name: rsyslog
+        state: started
+        enabled: true

--- a/tasks/Cat1/UBTU24-10xxxx.yml
+++ b/tasks/Cat1/UBTU24-10xxxx.yml
@@ -16,10 +16,10 @@
     state: absent
     purge: "{{ ubtu24stig_purge_apt }}"
 
-- name: HIGH | UBTU-24-100040 | PATCH | Ubuntu 24.04 LTS must not have the  rsh-server package installed.
+- name: HIGH | UBTU-24-100040 | PATCH | Ubuntu 24.04 LTS must not have the rsh-server package installed.
   when: ubtu24stig_100040
   tags:
-    - UBTU-24-100030
+    - UBTU-24-100040
     - CAT1
     - CCI-000381
     - SRG-OS-000095-GPOS-00049
@@ -50,6 +50,7 @@
   ansible.builtin.package:
     name: ssh
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: HIGH | UBTU-24-100810 | PATCH | Ubuntu 24.04 LTS must use SSH to protect the confidentiality and integrity of transmitted information.
   when: ubtu24stig_100810
@@ -80,7 +81,7 @@
     - CAT1
     - CCI-000213
     - SRG-OS-000080-GPOS-00048
-    - SV-270675r1066514_rule
+    - SV-270675r1137691_rule
     - V-270675
     - NIST800-53R4_AC-3
     - bootloader

--- a/tasks/Cat1/UBTU24-30xxxx.yml
+++ b/tasks/Cat1/UBTU24-30xxxx.yml
@@ -28,21 +28,17 @@
     - CAT1
     - CCI-000366
     - SRG-OS-000480-GPOS-00227
-    - SV-270711r1066622_rule
+    - SV-270711r1101772_rule
     - V-270711
     - NIST800-53R4_CM-6
     - gnome
-  block:
-    - name: HIGH | UBTU-24-300025 | AUDIT | Ubuntu 24.04 LTS must disable the x86 Ctrl-Alt-Delete key sequence if a graphical user interface is installed.
-      ansible.builtin.command: gsettings get org.gnome.settings-daemon.plugins.media-keys logout
-      changed_when: true
-      register: discovered_gui_ctrl_alt_del
-
-    - name: HIGH | UBTU-24-300025 | PATCH | Ubuntu 24.04 LTS must disable the x86 Ctrl-Alt-Delete key sequence if a graphical user interface is installed.
-      when: "'@as []' in discovered_gui_ctrl_alt_del.stdout"
-      ansible.builtin.command: gsettings set org.gnome.settings-daemon.plugins.media-keys logout []
-      changed_when: true
-      notify: Update_dconf
+  community.general.ini_file:
+    path: /etc/dconf/db/local.d/00-screensaver
+    section: "org/gnome/settings-daemon/plugins/media-keys"
+    option: logout=
+    value: "['']"
+    mode: 'u-x,go-wx'
+  notify: Update_dconf
 
 - name: HIGH | UBTU-24-300026 | PATCH | Ubuntu 24.04 LTS must disable the x86 Ctrl-Alt-Delete key sequence.
   when: ubtu24stig_300026
@@ -67,8 +63,8 @@
     - CAT1
     - CCI-000366
     - SRG-OS-000480-GPOS-00227
-    - SV-260571r991589_rule
-    - V-260571
+    - SV-270713r1066628_rule
+    - V-260573
     - NIST800-53R4_CM-6
     - password
   vars:
@@ -110,7 +106,7 @@
     - CAT1
     - CCI-000366
     - SRG-OS-000480-GPOS-00227
-    - SV-270714r1067119_rule
+    - SV-270714r1134808_rule
     - V-270714
     - NIST800-53R4_CM-6
     - password

--- a/tasks/Cat1/UBTU24-60xxxx.yml
+++ b/tasks/Cat1/UBTU24-60xxxx.yml
@@ -8,7 +8,7 @@
     - CCI-002450
     - SRG-OS-000396-GPOS-00176
     - SRG-OS-000478-GPOS-00243
-    - SV-270744r1066721_rule
+    - SV-270744r1137699_rule
     - V-270744
     - NIST800-53R4_SC-13
     - fips
@@ -67,10 +67,6 @@
       failed_when: discovered_sudo_group_users.rc not in [ 0, 1 ]
       register: discovered_sudo_group_users
 
-    - name: HIGH | UBTU-24-600130 | AUDIT | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Remove members
-      ansible.builtin.set_fact:
-        discovered_sudo_group_users_list: "{{ discovered_sudo_group_users.stdout | split(',') }}"
-
     - name: HIGH | UBTU-24-600130 | PATCH | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Ensure member exist
       ansible.builtin.user:
         name: "{{ item }}"
@@ -78,14 +74,12 @@
         groups: sudo
       loop: "{{ ubtu24stig_sudo_group_users }}"
 
-    - name: HIGH | UBTU-24-600130 | AUDIT | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Compare existing to required
-      ansible.builtin.set_fact:
-        sudo_group_members_not_required: "{{ discovered_sudo_group_users_list | difference(ubtu24stig_sudo_group_users) }}"
-
     - name: HIGH | UBTU-24-600130 | PATCH | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Remove user not in required list
-      when: ubtu24stig_disruption_high
-      ansible.builtin.command: gpasswd -d "{{ item }}" sudo
-      loop: "{{ sudo_group_members_not_required }}"
+      when:
+        - ubtu24stig_disruption_high
+        - item not in ubtu24stig_sudo_group_users
+      ansible.builtin.command: "gpasswd -d {{ item }} sudo"
+      loop: "{{ discovered_sudo_group_users.stdout.split(',') }}"
       changed_when: true
 
     - name: HIGH | UBTU-24-600130 | WARN | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | Warning
@@ -93,7 +87,7 @@
         - not ubtu24stig_disruption_high
         - sudo_group_members_not_required.stdout is defined
       ansible.builtin.debug:
-        msg: "Warning!! The following users {{ sudo_group_members_not_required }} have been found in the sudo group but not part of the 'ubtu24stig_sudo_group_required' variable"
+        msg: "Warning!! The following users {{ sudo_group_members_not_required }} have been found in the sudo group but not part of the 'ubtu24stig_sudo_group_users' variable"
 
     - name: HIGH | UBTU-24-600130 | WARN | Ubuntu 24.04 LTS must ensure only users who need access to security functions are part of sudo group. | warn_count
       when:

--- a/tasks/Cat1/UBTU24-70xxxx.yml
+++ b/tasks/Cat1/UBTU24-70xxxx.yml
@@ -1,0 +1,14 @@
+---
+
+- name: HIGH | UBTU-24-700400 | AUDIT | Ubuntu 24.04 LTS must be a vendor-supported release.
+  when: ubtu24stig_700400
+  tags:
+    - UBTU-24-700400
+    - CAT1
+    - CCI-002605
+    - SRG-OS-000480-GPOS-00227
+    - SV-278917r1155246_rule
+    - V-278917
+    - NIST800-53R4_CM-6
+  ansible.builtin.debug:
+    msg: "System is running a vendor supported release as per assert checks at the beginning of the playbook - {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }}"

--- a/tasks/Cat1/main.yml
+++ b/tasks/Cat1/main.yml
@@ -15,3 +15,7 @@
 - name: Run Cat 1 STIG 60xxxx
   ansible.builtin.import_tasks:
     file: UBTU24-60xxxx.yml
+
+- name: Run Cat 1 STIG 70xxxx
+  ansible.builtin.import_tasks:
+    file: UBTU24-70xxxx.yml

--- a/tasks/Cat2/UBTU24-10xxxx.yml
+++ b/tasks/Cat2/UBTU24-10xxxx.yml
@@ -14,6 +14,7 @@
   ansible.builtin.package:
     name: aide
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-100110 | PATCH | Ubuntu 24.04 LTS must configure AIDE to perform file integrity checking on the file system.
   when:
@@ -25,7 +26,7 @@
     - CAT2
     - CCI-002696
     - SRG-OS-000445-GPOS-00199
-    - SV-270650r1066439_rule
+    - SV-270650r1134802_rule
     - V-270650
     - NIST800-53R4_SI-6
     - aide
@@ -68,13 +69,13 @@
     - aide
   block:
     - name: MEDIUM | UBTU-24-100120 | AUDIT | Ubuntu 24.04 LTS must be configured so that the script that runs each 30 days or less to check file integrity is the default. | capture sha1sum
-      ansible.builtin.command: sha256sum /etc/aide/aide.conf 2>/dev/null
+      ansible.builtin.command: sha256sum /etc/aide/aide.conf
       changed_when: false
       failed_when: discovered_cron_script_sha256.rc not in [ 0, 1 ]
       register: discovered_cron_script_sha256
 
     - name: MEDIUM | UBTU-24-100120 | PATCH | Ubuntu 24.04 LTS must be configured so that the script that runs each 30 days or less to check file integrity is the default. | replace if needed
-      when: "'458aea46ab75906c3d9ad7f174a03b4ab62ee389fc4b8fb3c0330aae3c765441' not in discovered_cron_script_sha256.stdout" # pragma: allowlist secret
+      when: "'458aea46ab75906c3d9ad7f174a03b4ab62ee389fc4b8fb3c0330aae3c765441' not in discovered_cron_script_sha256.stdout"  # pragma: allowlist secret
       ansible.builtin.shell: |
         apt download aide-common; dpkg-deb --fsys-tarfile /tmp/aide-common_*.deb | dpkg-deb --fsys-tarfile /tmp/aide-common_*.deb | sudo tar -x --wildcards ./usr/share/aide/config/cron.daily/dailyaidecheck -C /; cp -f /usr/share/aide/config/cron.daily/dailyaidecheck /etc/cron.daily/dailyaidecheck*
       changed_when: true
@@ -116,6 +117,7 @@
       ansible.builtin.package:
         name: rsyslog
         state: present
+        lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
     - name: MEDIUM | UBTU-24-100200 | PATCH | Ubuntu 24.04 LTS must be configured to preserve log records from failure events.
       ansible.builtin.systemd_service:
@@ -139,6 +141,7 @@
   ansible.builtin.package:
     name: ufw
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-100310 | PATCH | Ubuntu 24.04 LTS must enable and run the Uncomplicated Firewall (ufw).
   when:
@@ -211,6 +214,7 @@
   ansible.builtin.package:
     name: auditd
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-100410 | PATCH | Ubuntu 24.04 LTS must produce audit records and reports containing information to establish when, where, what type, the source, and the outcome for all DOD-defined auditable events and actions in near real time.
   when: ubtu24stig_100410
@@ -286,6 +290,7 @@
   ansible.builtin.package:
     name: apparmor
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-100510 | PATCH | Ubuntu 24.04 LTS must be configured to use AppArmor.
   when:
@@ -317,17 +322,18 @@
     - CAT2
     - CCI-000366
     - SRG-OS-000480-GPOS-00225
-    - SV-260478r991587_rule
+    - SV-270661r1067175_rule
     - V-260478
     - NIST800-53R4_CM-6
     - packages
   ansible.builtin.package:
     name: libpam-pwquality
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-100650 | PATCH | Ubuntu 24.04 LTS must have the "SSSD" package installed.
   when:
-    - ubtu24stig_100600
+    - ubtu24stig_100650
     - ubtu24stig_use_sssd
     - ubtu24stig_disruption_high
   tags:
@@ -348,6 +354,7 @@
   ansible.builtin.package:
     name: libpam-sss
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
   loop: "{{ ubtu24stig_sssd_packages }}"
 
 - name: MEDIUM | UBTU-24-100660 | PATCH | Ubuntu 24.04 LTS must use the "SSSD" package for multifactor authentication services.
@@ -431,7 +438,7 @@
     - CAT2
     - CCI-000068
     - SRG-OS-000033-GPOS-00014
-    - SV-270669r1067112_rule
+    - SV-270669r1134804_rule
     - V-270669
     - NIST800-53R4_AC-17
     - ssh
@@ -466,7 +473,7 @@
     - CAT2
     - CCI-001453
     - SRG-OS-000250-GPOS-00093
-    - SV-270671r1067118_rule
+    - SV-270671r1155244_rule
     - V-270671
     - NIST800-53R4_AC-17
     - ssh
@@ -490,6 +497,7 @@
   ansible.builtin.package:
     name: opensc-pkcs11
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-100910 | PATCH | Ubuntu 24.04 LTS must accept Personal Identity Verification (PIV) credentials managed through the Privileged Access Management (PAM)  framework.
   when: ubtu24stig_100910
@@ -505,6 +513,7 @@
   ansible.builtin.package:
     name: libpam-pkcs11
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-101000 | PATCH | Ubuntu 24.04 LTS must allow users to directly initiate a session lock for all connection types.
   when: ubtu24stig_101000
@@ -521,6 +530,7 @@
   ansible.builtin.package:
     name: vlock
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
 - name: MEDIUM | UBTU-24-102010 | PATCH | Ubuntu 24.04 LTS must initiate session audits at system startup.
   when: ubtu24stig_102010
@@ -529,8 +539,8 @@
     - CAT2
     - CCI-001464
     - SRG-OS-000254-GPOS-00095
-    - SV-260471r991555_rule
-    - V-260471
+    - SV-270676r1155245_rule
+    - V-270676
     - NIST800-53R4_AU-14
     - bootloader
   block:

--- a/tasks/Cat2/UBTU24-20xxxx.yml
+++ b/tasks/Cat2/UBTU24-20xxxx.yml
@@ -9,45 +9,23 @@
     - CAT2
     - CCI-000057
     - SRG-OS-000029-GPOS-00010
-    - SV-270678r1066523_rule
+    - SV-270678r1101791_rule
     - V-270678
     - NIST800-53R4_AC-11
     - gnome
-  block:
-    - name: MEDIUM | UBTU-24-200020 | PATCH | Ubuntu 24.04 LTS must initiate a graphical session lock after 10 minutes of inactivity. | get lock-enabled
-      ansible.builtin.command: gsettings get org.gnome.desktop.screensaver lock-enabled
-      changed_when: false
-      failed_when: discovered_gnome_screensaver_lock_enabled.rc not in [ 0, 1 ]
-      register: discovered_gnome_screensaver_lock_enabled
+  community.general.ini_file:
+    path: /etc/dconf/db/local.d/00-screensaver
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    mode: 'u-x,go-wx'
+  notify: Update_dconf
+  loop:
+    - { section: org/gnome/desktop/screensaver, option: lock-enabled, value: true }
+    - { section: org/gnome/desktop/screensaver, option: lock-delay, value: 'uint32 0' }
+    - { section: org/gnome/desktop/session, option: idle-delay, value: "uint32 {{ ubtu24stig_screen_idle_delay }}" }
 
-    - name: MEDIUM | UBTU-24-200020 | PATCH | Ubuntu 24.04 LTS must initiate a graphical session lock after 10 minutes of inactivity. | set lock-enabled
-      when: "'true' not in discovered_gnome_screensaver_lock_enabled.stdout"
-      ansible.builtin.command: gsettings set org.gnome.desktop.screensaver lock-enabled true
-      changed_when: true
-
-    - name: MEDIUM | UBTU-24-200020 | PATCH | Ubuntu 24.04 LTS must initiate a graphical session lock after 10 minutes of inactivity. | get lock-delay
-      ansible.builtin.command: gsettings get org.gnome.desktop.screensaver lock-delay
-      changed_when: false
-      failed_when: discovered_gnome_screensaver_lock_delay.rc not in [ 0, 1 ]
-      register: discovered_gnome_screensaver_lock_delay
-
-    - name: MEDIUM | UBTU-24-200020 | PATCH | Ubuntu 24.04 LTS must initiate a graphical session lock after 10 minutes of inactivity. | set lock-delay
-      when: "'uint32' not in discovered_gnome_screensaver_lock_delay.stdout"
-      ansible.builtin.command: gsettings set org.gnome.desktop.screensaver lock-delay 0
-      changed_when: true
-
-    - name: MEDIUM | UBTU-24-200020 | PATCH | Ubuntu 24.04 LTS must initiate a graphical session lock after 10 minutes of inactivity. | get idle-delay
-      ansible.builtin.command: gsettings get org.gnome.desktop.session idle-delay
-      changed_when: false
-      failed_when: discovered_gnome_session_idle_delay.rc not in [ 0, 1 ]
-      register: discovered_gnome_session_idle_delay
-
-    - name: MEDIUM | UBTU-24-200020 | PATCH | Ubuntu 24.04 LTS must initiate a graphical session lock after 10 minutes of inactivity. | set idle-delay
-      when: "'uint32 900' not in discovered_gnome_session_idle_delay.stdout"
-      ansible.builtin.command: gsettings set org.gnome.desktop.session idle-delay 600
-      changed_when: true
-
-- name: MEDIUM | UBTU-24-200040 | PATCH | Ubuntu 24.04 LTS must retain a user's session lock until that user reestablishes access using established identification and authentication procedures.
+- name: MEDIUM | UBTU-24-200040 | PATCH | Ubuntu 24.04 LTS must prevent a user from overriding the disabling of the graphical user interface automount function.
   when:
     - ubtu24stig_200040
     - ubtu24stig_gui
@@ -56,20 +34,100 @@
     - CAT2
     - CCI-000056
     - SRG-OS-000028-GPOS-00009
-    - SV-270679r1066526_rule
+    - SRG-OS-000114-GPOS-00059
+    - SRG-OS-000378-GPOS-00163
+    - SRG-OS-000480-GPOS-00227
+    - SV-270679r1107295_rule
     - V-270679
     - NIST800-53R4_AC-11
     - gnome
-  block:
-    - name: MEDIUM | UBTU-24-200040 | AUDIT | Ubuntu 24.04 LTS must retain a user's session lock until that user reestablishes access using established identification and authentication procedures. | get settings
-      ansible.builtin.command: gsettings get org.gnome.desktop.screensaver lock-enabled
-      changed_when: false
-      register: discovered_gui_screensaver_lock
+  ansible.builtin.lineinfile:
+    path: /etc/dconf/db/local.d/locks/00-security-settings-lock
+    regexp: ^org\/gnome\/desktop\/media-handling\/automount-open
+    line: '/org/gnome/desktop/media-handling/automount-open'
+    create: true
+    mode: 'u-x,go-wx'
+  notify: Update_dconf
 
-    - name: MEDIUM | UBTU-24-200040 | PATCH | Ubuntu 24.04 LTS must retain a user's session lock until that user reestablishes access using established identification and authentication procedures. | set settings
-      when: "'true' not in discovered_gui_screensaver_lock"
-      ansible.builtin.command: gsettings set org.gnome.desktop.screensaver lock-enabled true
-      changed_when: true
+- name: MEDIUM | UBTU-24-200041 | PATCH | Ubuntu 24.04 LTS must prevent a user from overriding the disabling of the graphical user interface autorun function.
+  when:
+    - ubtu24stig_200041
+    - ubtu24stig_gui
+  tags:
+    - UBTU-24-200041
+    - CAT2
+    - CCI-000778
+    - CCI-001958
+    - SRG-OS-000114-GPOS-00059
+    - SRG-OS-000378-GPOS-00163
+    - SRG-OS-000480-GPOS-00227
+    - SV-274872r1107297_rule
+    - V-274872
+    - NIST800-53R4_IA-3
+    - gnome
+  ansible.builtin.lineinfile:
+    path: etc/dconf/db/local.d/locks/00-security-settings-lock
+    regexp: ^\/org\/gnome\/desktop\/media-handling\/autorun-never
+    line: '/org/gnome/desktop/media-handling/autorun-never'
+    create: true
+    mode: 'u-x,go-wx'
+  notify: Update_dconf
+
+- name: MEDIUM | UBTU-24-200042 | PATCH | Ubuntu 24.04 LTS must prevent a user from overriding the disabling of the graphical user smart card removal action.
+  when:
+    - ubtu24stig_200042
+    - ubtu24stig_gui
+  tags:
+    - UBTU-24-200042
+    - CAT2
+    - CCI-000056
+    - CCI-000057
+    - CCI-000058
+    - SRG-OS-000028-GPOS-00009
+    - SRG-OS-000030-GPOS-00011
+    - SV-274873r1107300_rule
+    - V-274873
+    - NIST800-53R4_AC-11
+    - gnome
+  ansible.builtin.lineinfile:
+    path: etc\/dconf\/db\/local.d\/locks\/00-security-settings-lock
+    regexp: ^\/org\/gnome\/settings-daemon\/peripherals\/smartcard\/removal-action
+    line: '/org/gnome/settings-daemon/peripherals/smartcard/removal-action'
+    create: true
+    mode: 'u-x,go-wx'
+  notify: Update_dconf
+
+- name: MEDIUM | UBTU-24-200043 | PATCH | Ubuntu 24.04 LTS must conceal, via the session lock, information previously visible on the display with a publicly viewable image.
+  when:
+    - ubtu24stig_200043
+    - ubtu24stig_gui
+  tags:
+    - UBTU-24-200043
+    - CAT2
+    - CCI-000060
+    - SRG-OS-000031-GPOS-00012
+    - SV-274871r1107302_rule
+    - V-274871
+    - NIST800-53R4_AC-11
+    - gnome
+  block:
+    - name: MEDIUM | UBTU-24-200043 | PATCH | Ubuntu 24.04 LTS must conceal, via the session lock, information previously visible on the display with a publicly viewable image.
+      community.general.ini_file:
+        path: /etc/dconf/db/local.d/00-security-settings
+        section: "org/gnome/desktop/screensaver"
+        option: picture-uri=
+        value: ''
+        mode: 'u-x,go-wx'
+      notify: Update_dconf
+
+    - name: MEDIUM | UBTU-24-200043 | PATCH | Ubuntu 24.04 LTS must conceal, via the session lock, information previously visible on the display with a publicly viewable image.
+      ansible.builtin.lineinfile:
+        path: etc\/dconf\/db\/local.d\/locks\/00-security-settings-lock
+        regexp: ^\/org\/gnome\/desktop\/screensaver/picture-uri
+        line: '/org/gnome/desktop/screensaver/picture-uri'
+        create: true
+        mode: 'u-x,go-wx'
+      notify: Update_dconf
 
 - name: MEDIUM | UBTU-24-200060 | PATCH | Ubuntu 24.04 LTS must automatically terminate a user session after inactivity timeouts have expired.
   when: ubtu24stig_200060
@@ -115,7 +173,7 @@
     - CAT2
     - CCI-000067
     - SRG-OS-000032-GPOS-00013
-    - SV-270681r1066532_rule
+    - SV-270681r1134806_rule
     - V-270681
     - NIST800-53R4_AC-17
     - syslog
@@ -175,6 +233,20 @@
     path: /etc/default/useradd
     regexp: (?i)^(#|)INACTIVE\s*=\s*\d*
     line: "INACTIVE={{ ubtu24stig_user_inactive_days }}"
+
+- name: MEDIUM | UBTU-24-200270 | PATCH | Ubuntu 24.04 LTS must audit any script or executable called by cron as root or by any privileged user.
+  when: ubtu24stig_200270
+  tags:
+    - UBTU-24-200270
+    - CAT2
+    - CCI-000172
+    - SRG-OS-000471-GPOS-00215
+    - SV-274870r1155243_rule
+    - V-274870
+    - NIST800-53R4_AU-12
+    - auditd
+  ansible.builtin.set_fact:
+    update_audit_template: true
 
 - name: MEDIUM | UBTU-24-200280 | Ubuntu 24.04 LTS must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.
   when: ubtu24stig_200280

--- a/tasks/Cat2/UBTU24-30xxxx.yml
+++ b/tasks/Cat2/UBTU24-30xxxx.yml
@@ -7,7 +7,7 @@
     - CAT2
     - CCI-001499
     - SRG-OS-000259-GPOS-00100
-    - SV-270696r1066577_rule
+    - SV-270696r1107306_rule
     - V-270696
     - NIST800-53R4_CM-5
     - permissions
@@ -15,7 +15,7 @@
     warn_control_id: 'MEDIUM | UBTU-24-300006'
   block:
     - name: MEDIUM | UBTU-24-300006 | AUDIT | Ubuntu 24.04 LTS library files must have mode 0755 or less permissive. | Discover
-      ansible.builtin.shell: find /lib /lib64 /usr/lib -perm /022 -type f -exec stat -c "%n" '{}' \;
+      ansible.builtin.shell: find /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type f -exec stat -c "%n" '{}' \;
       changed_when: false
       failed_when: discovered_system_lib_files_perms.rc not in [ 0, 1 ]
       register: discovered_system_lib_files_perms
@@ -51,7 +51,7 @@
     - CAT2
     - CCI-001499
     - SRG-OS-000259-GPOS-00100
-    - SV-270697r1066580_rule
+    - SV-270697r1107308_rule
     - V-270697
     - NIST800-53R4_CM-5
     - permissions
@@ -59,7 +59,7 @@
     warn_control_id: 'MEDIUM | UBTU-24-300007'
   block:
     - name: MEDIUM | UBTU-24-300007 | AUDIT | Ubuntu 24.04 LTS library files must be owned by root. | Discover
-      ansible.builtin.shell: find /lib /usr/lib /lib64 ! -user root -type f -exec stat -c "%n" '{}' \;
+      ansible.builtin.shell: find /lib /usr/lib /lib64 /usr/lib64 ! -user root -type f -exec stat -c "%n" '{}' \;
       changed_when: false
       failed_when: discovered_system_lib_files_owner.rc not in [ 0, 1 ]
       register: discovered_system_lib_files_owner
@@ -95,7 +95,7 @@
     - CAT2
     - CCI-001499
     - SRG-OS-000259-GPOS-00100
-    - SV-270698r1066583_rule
+    - SV-270698r1101751_rule
     - V-270698
     - NIST800-53R4_CM-5
     - permissions
@@ -103,7 +103,7 @@
     warn_control_id: 'MEDIUM | UBTU-24-300008'
   block:
     - name: MEDIUM | UBTU-24-300008 | AUDIT | Ubuntu 24.04 LTS library directories must be owned by root. | Discover
-      ansible.builtin.shell: find /lib /usr/lib /lib64 ! -user root -type d -exec stat -c "%n" '{}' \;
+      ansible.builtin.shell: find /lib /usr/lib /lib64 /usr/lib64 ! -user root -type d -exec stat -c "%n" '{}' \;
       changed_when: false
       failed_when: discovered_system_lib_dirs_owner.rc not in [ 0, 1 ]
       register: discovered_system_lib_dirs_owner
@@ -139,7 +139,7 @@
     - CAT2
     - CCI-001499
     - SRG-OS-000259-GPOS-00100
-    - SV-270699r1066586_rule
+    - SV-270699r1107310_rule
     - V-270699
     - NIST800-53R4_CM-5
     - permissions
@@ -147,7 +147,7 @@
     warn_control_id: 'MEDIUM | UBTU-24-300009'
   block:
     - name: MEDIUM | UBTU-24-300009 | AUDIT | Ubuntu 24.04 LTS library files must be group-owned by root or system account. | Discover
-      ansible.builtin.shell: find /lib /usr/lib /lib64 -type f -uid +"{{ min_int_uid }}"  -exec stat -c "%n" '{}' \;
+      ansible.builtin.shell: find /lib /usr/lib /lib64 /usr/lib64 -type f -uid +"{{ min_int_uid }}"  -exec stat -c "%n" '{}' \;
       changed_when: false
       failed_when: discovered_system_lib_files_group.rc not in [ 0, 1 ]
       register: discovered_system_lib_files_group
@@ -315,8 +315,8 @@
     - CAT2
     - CCI-001499
     - SRG-OS-000259-GPOS-00100
-    - SV-260496r991560_rule
-    - V-260496
+    - SV-270703r1066598_rule
+    - V-270703
     - NIST800-53R4_CM-5
     - permissions
   vars:
@@ -384,6 +384,53 @@
     regexp: (?i)^(#|)enforcing\s*=
     line: 'enforcing = 1'
 
+- name: MEDIUM | UBTU-24-300019 | PATCH | Ubuntu 24.04 LTS must restrict privilege elevation to authorized personnel.
+  when: ubtu24stig_300019
+  tags:
+    - UBTU-24-300019
+    - CAT2
+    - CCI-002038
+    - SRG-OS-000373-GPOS-00156
+    - SV-274869r1107312_rule
+    - V-274869
+    - NIST800-53R4_IA-11
+    - password
+  ansible.builtin.lineinfile:
+    path: "{{ item }}"
+    regexp: '(?i)^ALL\s+ALL=\(ALL(:ALL)?\)\s+ALL'
+    state: absent
+  loop: "{{ prelim_sudoers_files.stdout_lines }}"
+
+- name: MEDIUM | UBTU-24-300020 | PATCH | Ubuntu 24.04 LTS must require users to provide a password for privilege escalation.
+  when: ubtu24stig_300020
+  tags:
+    - UBTU-24-300020
+    - CAT2
+    - CCI-000366
+    - SRG-OS-000373-GPOS-00156
+    - SRG-OS-000373-GPOS-00157
+    - SRG-OS-000373-GPOS-00158
+    - SV-274868r1107313_rule
+    - V-274868
+    - NIST800-53R4_CM-6
+    - password
+  block:
+    - name: MEDIUM | UBTU-24-300020 | AUDIT | Ubuntu 24.04 LTS must require users to provide a password for privilege escalation. | find
+      ansible.builtin.shell: grep -Ei '(nopasswd)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+      become: true
+      changed_when: false
+      failed_when: false
+      register: discovered_sudoers_nopasswd
+
+    - name: MEDIUM | UBTU-24-300020 | PATCH | Ubuntu 24.04 LTS must require users to provide a password for privilege escalation. | patch
+      when: discovered_sudoers_nopasswd.stdout | length > 0
+      ansible.builtin.replace:
+        path: "{{ item }}"
+        regexp: '^((?!#|{% for name in ubtu24stig_sudoers_exclude_nopasswd_list %}{{ name }}{% if not loop.last -%}|{%- endif -%}{% endfor %}).*)NOPASSWD(.*)'
+        replace: '\1PASSWD\2'
+        validate: '/usr/sbin/visudo -cf %s'
+      loop: "{{ discovered_sudoers_nopasswd.stdout_lines }}"
+
 - name: MEDIUM | UBTU-24-300021 | PATCH | Ubuntu 24.04 LTS must require users to reauthenticate for privilege escalation or when changing roles.
   when: ubtu24stig_300021
   tags:
@@ -391,26 +438,28 @@
     - CAT2
     - CCI-000366
     - SRG-OS-000480-GPOS-00227
-    - SV-270707r1066610_rule
+    - SV-270707r1101786_rule
     - V-270707
     - NIST800-53R4_CM-6
     - sudo
   block:
     - name: MEDIUM | UBTU-24-300021 | AUDIT | Ubuntu 24.04 LTS must require users to reauthenticate for privilege escalation or when changing roles. | capture config
-      ansible.builtin.shell: grep -Ei '(nopasswd|!authenticate)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+      ansible.builtin.shell: grep -Ei '^[^#]*!authenticate' /etc/sudoers /etc/sudoers.d 2>/dev/null | cut -d':' -f1 | sort -u
+      become: true
       changed_when: false
-      failed_when: discovered_sudo_nopasswd.rc not in [ 0, 1 ]
-      register: discovered_sudo_nopasswd
+      failed_when: discovered_sudo_authenticate.rc not in [ 0, 1, 2 ]
+      register: discovered_sudo_authenticate
 
-    - name: MEDIUM | UBTU-24-300021 | PATCH | Ubuntu 24.04 LTS must require users to reauthenticate for privilege escalation or when changing roles. | Remove NOPASSWD
+    - name: MEDIUM | UBTU-24-300021 | PATCH | Ubuntu 24.04 LTS must require users to reauthenticate for privilege escalation or when changing roles.
       when:
-        - discovered_sudo_nopasswd.stdout_lines is defined
+        - discovered_sudo_authenticate.stdout_lines | length > 0
         - ubtu24stig_disruption_high
       ansible.builtin.replace:
         path: "{{ item }}"
-        regexp: (?i)(nopasswd|!authenticate)
-        replace: ''
-      loop: "{{ discovered_sudo_nopasswd.stdout_lines }}"
+        regexp: '^((?!#|{% for name in ubtu24stig_sudoers_exclude_nopasswd_list %}{{ name }}{% if not loop.last -%}|{%- endif -%}{% endfor %}).*)!authenticate(.*)'
+        replace: '\1\3'
+        validate: '/usr/sbin/visudo -cf %s'
+      loop: "{{ discovered_sudo_authenticate.stdout_lines }}"
 
 - name: MEDIUM | UBTU-24-300023 | PATCH | Ubuntu 24.04 LTS SSH daemon must prevent remote hosts from connecting to the proxy display.
   when: ubtu24stig_300023
@@ -469,7 +518,7 @@
     - CCI-001958
     - SRG-OS-000690-GPOS-00140
     - SRG-OS-000378-GPOS-00163
-    - SV-270718r1067128_rule
+    - SV-270718r1134811_rule
     - V-270718
     - NIST800-53R4_IA-3
     - hardware

--- a/tasks/Cat2/UBTU24-40xxxx.yml
+++ b/tasks/Cat2/UBTU24-40xxxx.yml
@@ -140,8 +140,8 @@
     - CCI-000000
     - CAT2
     - SRG-OS-000073-GPOS-00041
-    - SV-260569r986291_rule
-    - V-260569
+    - SV-270725r1101789_rule
+    - V-270725
     - NIST800-53R4_NA
     - password
   block:

--- a/tasks/Cat2/UBTU24-60xxxx.yml
+++ b/tasks/Cat2/UBTU24-60xxxx.yml
@@ -75,7 +75,7 @@
     - CAT2
     - CCI-001190
     - SRG-OS-000184-GPOS-00078
-    - SV-270746r1066727_rule
+    - SV-270746r1155242_rule
     - V-270746
     - NIST800-53R4_SC-24
   block:
@@ -146,7 +146,7 @@
     - CAT2
     - CCI-001090
     - SRG-OS-000138-GPOS-00069
-    - SV-270750r1066739_rule
+    - SV-270750r1117267_rule
     - V-270750
     - NIST800-53R4_SC-4
     - permissions
@@ -220,7 +220,9 @@
         value: '1'
 
 - name: MEDIUM | UBTU-24-600200 | PATCH | Ubuntu 24.04 LTS must configure the uncomplicated firewall to rate-limit impacted network interfaces.
-  when: ubtu24stig_600200
+  when:
+    - ubtu24stig_600200
+    - ubtu24stig_disruption_high
   tags:
     - UBTU-24-600200
     - CAT2

--- a/tasks/Cat2/UBTU24-70xxxx.yml
+++ b/tasks/Cat2/UBTU24-70xxxx.yml
@@ -7,7 +7,7 @@
     - CAT2
     - CCI-001312
     - SRG-OS-000205-GPOS-00083
-    - SV-270756r1066757_rule
+    - SV-270756r1134814_rule
     - V-270756
     - NIST800-53R4_SI-11
     - permissions
@@ -15,7 +15,7 @@
     warn_control_id: 'MEDIUM | UBTU-24-700010'
   block:
     - name: MEDIUM | UBTU-24-700010 | AUDIT | Ubuntu 24.04 LTS must generate error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries. | find files
-      ansible.builtin.shell: find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' {% if ubtu24stig_700010 %}! -name '*syslog' {% endif %}-type f -exec stat -c "%n" {} \;
+      ansible.builtin.shell: find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' ! -name 'history*' ! -name '*eipp.log.xz' {% if ubtu24stig_700010 %}! -name '*syslog' {% endif %}-type f -exec stat -c "%n" {} \;
       changed_when: false
       failed_when: discovered_var_log_logfiles.rc not in [ 0, 1 ]
       register: discovered_var_log_logfiles
@@ -109,7 +109,7 @@
     - permissions
   ansible.builtin.file:
     path: /usr/bin/journalctl
-    mode: 'u=rwx,g=r,o-rwx'
+    mode: 'g-wx,o-rwx'
 
 - name: MEDIUM | UBTU-24-700040 | PATCH | Ubuntu 24.04 LTS must be configured so that the "journalctl" command is owned by "root".
   when:
@@ -138,8 +138,8 @@
     - CAT2
     - CCI-001314
     - SRG-OS-000206-GPOS-00084
-    - SV-270759r1068367_rule
-    - V-270759
+    - SV-270760r1066769_rule
+    - V-270760
     - NIST800-53R4_SI-11
     - journald
     - permissions
@@ -499,16 +499,3 @@
   loop:
     - {regexp: 'Unattended-Upgrade::Remove-Unused-Kernel-Packages', line: 'Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";'}
     - {regexp: 'Unattended-Upgrade::Remove-Unused-Dependencies', line: 'Unattended-Upgrade::Remove-Unused-Dependencies "true";'}
-
-- name: MEDIUM | UBTU-24-700400 | AUDIT | Ubuntu 24.04 LTS must be a vendor-supported release.
-  when: ubtu24stig_700400
-  tags:
-    - UBTU-24-700400
-    - CAT2
-    - CCI-002605
-    - SRG-OS-000439-GPOS-00195
-    - SV-270774r1066811_rule
-    - V-270774
-    - NIST800-53R4_SI-2
-  ansible.builtin.debug:
-    msg: "System is running a vendor supported release as per assert checks at the beginning of the playbook - {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }}"

--- a/tasks/Cat2/UBTU24-900xxx.yml
+++ b/tasks/Cat2/UBTU24-900xxx.yml
@@ -267,8 +267,8 @@
     - CAT2
     - CCI-000172
     - SRG-OS-000064-GPOS-00033
-    - SV-260616r958446_rule
-    - V-260616
+    - SV-270791r1066862_rule
+    - V-270791
     - NIST800-53R4_AU-12
     - auditd
   ansible.builtin.set_fact:
@@ -405,8 +405,7 @@
     update_audit_template: true
 
 - name: MEDIUM | UBTU-24-900300 | Ubuntu 24.04 LTS must generate audit records for successful/unsuccessful uses of the chage command.
-  when:
-    - ubtu24stig_900300
+  when: ubtu24stig_900300
   tags:
     - UBTU-24-900300
     - CAT2

--- a/tasks/Cat2/UBTU24-901xxx.yml
+++ b/tasks/Cat2/UBTU24-901xxx.yml
@@ -11,7 +11,7 @@
     - CCI-001494
     - SRG-OS-000256-GPOS-00097
     - SRG-OS-000257-GPOS-00098
-    - SV-270821r1068391_rule
+    - SV-270821r1134818_rule
     - V-270821
     - NIST800-53R4_AU-9
     - permissions
@@ -35,7 +35,7 @@
     - CCI-001494
     - SRG-OS-000256-GPOS-00097
     - SRG-OS-000257-GPOS-00098
-    - SV-270822r1068392_rule
+    - SV-270822r1134821_rule
     - V-270822
     - NIST800-53R4_AU-9
     - auditd
@@ -59,7 +59,7 @@
     - CCI-001494
     - SRG-OS-000256-GPOS-00097
     - SRG-OS-000257-GPOS-00098
-    - SV-270823r1068393_rule
+    - SV-270823r1134824_rule
     - V-270823
     - NIST800-53R4_AU-9
     - auditd
@@ -298,27 +298,3 @@
         path: "{{ discovered_auditd_logfile.stdout | dirname }}"
         state: directory
         mode: 'g-w,o-rwx'
-
-- name: MEDIUM | UBTU-24-901890 | PATCH | Ubuntu 24.04 LTS must use cryptographic mechanisms to protect the integrity of audit tools.
-  when: ubtu24stig_901890
-  tags:
-    - UBTU-24-901890
-    - CAT2
-    - CCI-001496
-    - SRG-OS-000278-GPOS-00108
-    - SV-270831r1066982_rule
-    - V-270831
-    - NIST800-53R4_AU-9
-    - aide
-  ansible.builtin.lineinfile:
-    path: /etc/aide/aide.conf
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.regexp }} {{ item.line }}"
-  loop:
-    - { regexp: '/sbin/auditctl', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
-    - { regexp: '/sbin/auditd', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
-    - { regexp: '/sbin/ausearch', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
-    - { regexp: '/sbin/aureport', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
-    - { regexp: '/sbin/autrace', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
-    - { regexp: '/sbin/audispd', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
-    - { regexp: '/sbin/augenrules', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }

--- a/tasks/Cat2/UBTU24-909xxx.yml
+++ b/tasks/Cat2/UBTU24-909xxx.yml
@@ -13,3 +13,26 @@
     - auditd
   ansible.builtin.set_fact:
     update_audit_template: true
+
+- name: MEDIUM | UBTU-24-909890 | PATCH | Ubuntu 24.04 LTS must use cryptographic mechanisms to protect the integrity of audit tools.
+  when: ubtu24stig_909890
+  tags:
+    - UBTU-24-909890
+    - CAT2
+    - CCI-001496
+    - SRG-OS-000278-GPOS-00108
+    - SV-270831r1135002_rule
+    - V-270831
+    - NIST800-53R4_AU-9
+    - aide
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.regexp }} {{ item.line }}"
+  loop:
+    - { regexp: '/sbin/auditctl', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
+    - { regexp: '/sbin/auditd', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
+    - { regexp: '/sbin/ausearch', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
+    - { regexp: '/sbin/aureport', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
+    - { regexp: '/sbin/autrace', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }
+    - { regexp: '/sbin/augenrules', line: 'p+i+n+u+g+s+b+acl+xattrs+sha512' }

--- a/tasks/Cat3/UBTU24-100xxx.yml
+++ b/tasks/Cat3/UBTU24-100xxx.yml
@@ -15,6 +15,7 @@
   ansible.builtin.package:
     name: systemd-timesyncd
     state: absent
+    purge: "{{ ubtu24stig_purge_apt }}"
 
 - name: LOW | UBTU-24-100020 | PATCH | Ubuntu 24.04 LTS must not have the "ntp" package installed.
   when: ubtu24stig_100020
@@ -31,6 +32,7 @@
   ansible.builtin.package:
     name: ntp
     state: absent
+    purge: "{{ ubtu24stig_purge_apt }}"
 
 - name: LOW | UBTU-24-100450 | PATCH | Ubuntu 24.04 LTS audit event multiplexor must be configured to offload audit logs onto a different system or storage media from the system being audited.
   when: ubtu24stig_100450
@@ -49,6 +51,7 @@
       ansible.builtin.package:
         name: audispd-plugins
         state: present
+        lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"
 
     - name: LOW | UBTU-24-100450 | PATCH | Ubuntu 24.04 LTS audit event multiplexor must be configured to offload audit logs onto a different system or storage media from the system being audited.
       ansible.builtin.lineinfile:
@@ -83,3 +86,4 @@
   ansible.builtin.package:
     name: chrony
     state: present
+    lock_timeout: "{{ ubtu24stig_apt_lock_timeout }}"

--- a/tasks/Cat3/UBTU24-200xxx.yml
+++ b/tasks/Cat3/UBTU24-200xxx.yml
@@ -7,7 +7,7 @@
     - CAT3
     - CCI-000054
     - SRG-OS-000027-GPOS-00008
-    - SV-270677r1066520_rule
+    - SV-270677r1101774_rule
     - V-270677
     - NIST800-53R4_AC-10
     - account

--- a/tasks/Cat3/UBTU24-400xxx.yml
+++ b/tasks/Cat3/UBTU24-400xxx.yml
@@ -10,7 +10,7 @@
     - CAT3
     - CCI-002007
     - SRG-OS-000383-GPOS-00166
-    - SV-270734r1066691_rule
+    - SV-270734r1155240_rule
     - V-270734
     - NIST800-53R4_IA-5
     - authorise

--- a/tasks/Cat3/UBTU24-600xxx.yml
+++ b/tasks/Cat3/UBTU24-600xxx.yml
@@ -7,7 +7,7 @@
     - CAT3
     - CCI-001090
     - SRG-OS-000138-GPOS-00069
-    - SV-270749r1067179_rule
+    - SV-270749r1137695_rule
     - V-270749
     - NIST800-53R4_SC-4
     - kernel

--- a/tasks/Cat3/UBTU24-90xxxx.yml
+++ b/tasks/Cat3/UBTU24-90xxxx.yml
@@ -62,12 +62,12 @@
       register: discovered_audit_cron_copy
 
     - name: LOW | UBTU-24-900950 | AUDIT | Ubuntu 24.04 LTS must have a crontab script running weekly to offload audit events of standalone systems. | Warning
-      when: discovered_audit_cron_copy.files is not defined
+      when: discovered_audit_cron_copy.files | length == 0
       ansible.builtin.debug:
         msg: "Warning!! No job for auditd to have logs copied off the system have been found"
 
     - name: LOW | UBTU-24-900950 | AUDIT | Ubuntu 24.04 LTS must have a crontab script running weekly to offload audit events of standalone systems.| Warn count
-      when: discovered_audit_cron_copy.files is not defined
+      when: discovered_audit_cron_copy.files | length == 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -1,18 +1,18 @@
 ---
 
-- name: "Pre Audit Setup | Set audit package name"
+- name: Pre Audit Setup | Set audit package name
   block:
     - name: Pre Audit Setup | Set audit package name | 64bit
       when: ansible_facts.machine == "x86_64"
       ansible.builtin.set_fact:
         audit_pkg_arch_name: AMD64
 
-    - name: "Pre Audit Setup | Set audit package name | ARM64"
-      when: ansible_facts.machine == "arm64"
+    - name: Pre Audit Setup | Set audit package name | ARM64
+      when: (ansible_facts.machine == "arm64" or ansible_facts.machine == "aarch64")
       ansible.builtin.set_fact:
         audit_pkg_arch_name: ARM64
 
-- name: "Pre Audit Setup | Download audit binary"
+- name: Pre Audit Setup | Download audit binary
   when: get_audit_binary_method == 'download'
   ansible.builtin.get_url:
     url: "{{ audit_bin_url }}{{ audit_pkg_arch_name }}"
@@ -20,13 +20,17 @@
     owner: root
     group: root
     checksum: "{{ audit_bin_version[audit_pkg_arch_name + '_checksum'] }}"
-    mode: 'u+x,go+x,go-w'
+    mode: 'u+x,go-w'
+    validate_certs: "{{ audit_bin_validate_certs }}"
+    url_username: "{{ audit_bin_url_username | default(omit) }}"
+    url_password: "{{ audit_bin_url_password | default(omit) }}"
+  no_log: true
 
-- name: "Pre Audit Setup | Copy audit binary"
+- name: Pre Audit Setup | Copy audit binary
   when: get_audit_binary_method == 'copy'
   ansible.builtin.copy:
-    src: "{{ audit_bin_copy_location }}"
+    src: "{{ audit_bin_copy_location }}/goss-linux-{{ audit_pkg_arch_name }}"
     dest: "{{ audit_bin }}"
     owner: root
     group: root
-    mode: 'go-w'
+    mode: 'u+x,go-w'

--- a/tasks/audit_only.yml
+++ b/tasks/audit_only.yml
@@ -1,10 +1,17 @@
 ---
 
-- name: "Audit_only | Show Audit Summary"
+- name: Audit_only | Fetch audit files
+  when:
+    - fetch_audit_output
+    - audit_only
+  ansible.builtin.import_tasks:
+    file: fetch_audit_output.yml
+
+- name: Audit_only | Show Audit Summary
   when: audit_only
   ansible.builtin.debug:
     msg: "{{ audit_results.split('\n') }}"
 
-- name: "Audit_only | Stop Playbook Audit Only selected"
+- name: Audit_only | Stop task for host as audit_only selected
   when: audit_only
-  ansible.builtin.meta: end_play
+  ansible.builtin.meta: end_host

--- a/tasks/check_prereqs.yml
+++ b/tasks/check_prereqs.yml
@@ -1,7 +1,14 @@
 ---
 
-- name: "PREREQ | If required install libselinux package to manage file changes."
-  when: '"libselinux-python3" not in ansible_facts.packages'
+# Prereq checks for the Ansible-Lockdown UB24-STIG role.
+# Previously installed `libselinux-python3` unconditionally — that's a
+# RHEL-template leak; Ubuntu uses AppArmor, not SELinux. The role's
+# actual on-target prereq is python3-apt for the apt module; that's
+# included in the stock Ubuntu cloud image, but we verify it here so
+# minimal containers also work.
+
+- name: "PREREQ | Ensure python3-apt is available for the apt module"
+  when: '"python3-apt" not in ansible_facts.packages'
   ansible.builtin.package:
-    name: libselinux-python3
+    name: python3-apt
     state: present

--- a/tasks/fetch_audit_output.yml
+++ b/tasks/fetch_audit_output.yml
@@ -8,6 +8,7 @@
     src: "{{ item }}"
     dest: "{{ audit_output_destination }}"
     flat: true
+  changed_when: true
   failed_when: false
   register: discovered_audit_fetch_state
   loop:
@@ -37,7 +38,7 @@
   block:
     - name: "POST | FETCH | Fetch files and copy to controller | Warning if issues with fetch_audit_files"
       ansible.builtin.debug:
-        msg: "Warning!! Problems writing to localhost at {{ audit_output_destination }} for audit file copy"
+        msg: "Warning!! Unable to write to localhost {{ audit_output_destination }} for audit file copy"
 
     - name: "POST | FETCH | Fetch files and copy to controller | Warning if issues with fetch_audit_files"
       vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     fail_msg: "This role can only be run against Ubuntu 24. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."
     success_msg: "This role is running against a supported OS {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }}"
 
-- name: "Check Ansible Version"
+- name: "Check ansible version"
   tags: always
   ansible.builtin.assert:
     that: ansible_version.full is version_compare(min_ansible_version, '>=')
@@ -16,7 +16,7 @@
     success_msg: "This role is running a supported version of ansible {{ ansible_version.full }} >= {{ min_ansible_version }}"
 
 - name: "Setup rules if container"
-  when: ansible_connection == 'docker' or ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+  when: ansible_connection in ["docker", "community.docker.docker"] or ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
   tags:
     - container_discovery
     - always
@@ -152,7 +152,7 @@
         state: directory
         owner: root
         group: root
-        mode: 'u=rwx,go=rx'
+        mode: 'go-w'
 
     - name: Create ansible facts file and levels applied if audit facts not present
       ansible.builtin.template:
@@ -160,7 +160,7 @@
         dest: "{{ ansible_facts_path }}/compliance_facts.fact"
         owner: root
         group: root
-        mode: 'u-x,go=r'
+        mode: 'go-wx'
 
 - name: Fetch audit files
   when:

--- a/tasks/parse_etc_password.yml
+++ b/tasks/parse_etc_password.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: "PRELIM | Parse /etc/passwd"
   tags: always
   block:

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,42 +1,33 @@
 ---
 
-- name: "Post Audit | Run post_remediation {{ benchmark }} audit" # noqa name[template]
-  ansible.builtin.command: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -o {{ post_audit_outfile }} -g \"{{ group_names }}\""
+- name: Post Audit | Run post_remediation {{ benchmark }} audit  # noqa name[template]
+  ansible.builtin.shell: "umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ post_audit_outfile }} -g \"{{ group_names }}\""  # noqa yaml[line-length]
   changed_when: true
   environment:
     AUDIT_BIN: "{{ audit_bin }}"
     AUDIT_CONTENT_LOCATION: "{{ audit_conf_dest | default('/opt') }}"
     AUDIT_FILE: goss.yml
 
-- name: Post Audit | Ensure audit files readable by users
-  ansible.builtin.file:
-    path: "{{ item }}"
-    mode: 'u-x,go=r'
-    state: file
-  loop:
-    - "{{ post_audit_outfile }}"
-    - "{{ pre_audit_outfile }}"
-
-- name: "Post Audit | Capture audit data if json format"
+- name: Post Audit | Capture audit data if json format
   when: audit_format == "json"
   block:
-    - name: "Post Audit | Capture audit data if json format"
+    - name: Post Audit | Capture audit data if json format
       ansible.builtin.shell: grep -E '"summary-line.*Count:.*Failed' "{{ post_audit_outfile }}" | cut -d'"' -f4
-      register: post_audit_summary
       changed_when: false
+      register: post_audit_summary
 
-    - name: "Post Audit | Set Fact for audit summary"
+    - name: Post Audit | Set Fact for audit summary
       ansible.builtin.set_fact:
         post_audit_results: "{{ post_audit_summary.stdout }}"
 
-- name: "Post Audit | Capture audit data if documentation format"
+- name: Post Audit | Capture audit data if documentation format
   when: audit_format == "documentation"
   block:
-    - name: "Post Audit | Capture audit data if documentation format"
-      ansible.builtin.command: "tail -2 {{ post_audit_outfile }}"
-      register: post_audit_summary
+    - name: Post Audit | Capture audit data if documentation format
+      ansible.builtin.shell: tail -2 "{{ post_audit_outfile }}"  | tac | tr '\n' ' '
       changed_when: false
+      register: post_audit_summary
 
-    - name: "Post Audit | Set Fact for audit summary"
+    - name: Post Audit | Set Fact for audit summary
       ansible.builtin.set_fact:
         post_audit_results: "{{ post_audit_summary.stdout }}"

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -1,45 +1,47 @@
 ---
 
-- name: "Pre Audit Setup | Setup the LE audit"
+- name: Pre Audit Setup | Setup the LE audit
   when: setup_audit
   tags: setup_audit
   ansible.builtin.include_tasks:
     file: LE_audit_setup.yml
 
-- name: "Pre Audit Setup | Ensure {{ audit_conf_dir }} exists" # noqa name[template]
+- name: Pre Audit Setup | Ensure existence of {{ audit_conf_dir }}  # noqa name[template]
   ansible.builtin.file:
     path: "{{ audit_conf_dir }}"
-    state: directory
     mode: 'go-w'
+    state: directory
 
-- name: "Pre Audit Setup | If using git for content set up"
+- name: Pre Audit Setup | If using git for content set up
   when: audit_content == 'git'
   block:
-    - name: "Pre Audit Setup | Install git"
+    - name: Pre Audit Setup | Install git
       ansible.builtin.package:
         name: git
         state: present
 
-    - name: "Pre Audit Setup | Retrieve audit content files from git"
+    - name: Pre Audit Setup | Retrieve audit content files from git
       ansible.builtin.git:
-        repo: "{{ audit_file_git }}"
+        repo: "{{ self_hosted_audit_repo | default(audit_file_git) }}"
         dest: "{{ audit_conf_dir }}"
         version: "{{ audit_git_version }}"
+        key_file: "{{ audit_content_key_file | default(omit) }}"
+      no_log: true
 
-- name: "Pre Audit Setup | Copy to audit content files to server"
+- name: Pre Audit Setup | Copy to audit content files to server
   when: audit_content == 'copy'
   ansible.builtin.copy:
     src: "{{ audit_conf_source }}"
     dest: "{{ audit_conf_dest }}"
     mode: preserve
 
-- name: "Pre Audit Setup | Unarchive audit content files on server"
+- name: Pre Audit Setup | Unarchive audit content files on server
   when: audit_content == 'archive'
   ansible.builtin.unarchive:
     src: "{{ audit_conf_source }}"
     dest: "{{ audit_conf_dest }}"
 
-- name: "Pre Audit Setup | Get audit content from url"
+- name: Pre Audit Setup | Get audit content from url
   when: audit_content == 'get_url'
   ansible.builtin.unarchive:
     src: "{{ audit_conf_source }}"
@@ -47,62 +49,63 @@
     remote_src: "{{ (audit_conf_source is contains('http')) | ternary(true, false) }}"
     extra_opts: "{{ (audit_conf_source is contains('github')) | ternary('--strip-components=1', []) }}"
 
-- name: "Pre Audit Setup | Check Goss is available"
+- name: Pre Audit Setup | Check Goss is available
   when: run_audit
   block:
-    - name: "Pre Audit Setup | Check for goss file"
+    - name: Pre Audit Setup | Check for goss file
       ansible.builtin.stat:
         path: "{{ audit_bin }}"
-      register: discovered_goss_available
+      register: prelim_goss_available
 
-    - name: "Pre Audit Setup | If audit ensure goss is available"
-      when: not discovered_goss_available.stat.exists
+    - name: Pre Audit Setup | If audit ensure goss is available
+      when: not prelim_goss_available.stat.exists
       ansible.builtin.assert:
+        that: prelim_goss_available['stat']['exists'] == true
         msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
 
-- name: "Pre Audit Setup | Copy ansible default vars values to test audit"
+- name: Pre Audit Setup | Copy ansible default vars values to test audit
+  when: run_audit
   tags:
     - goss_template
     - run_audit
-  when: run_audit
   ansible.builtin.template:
     src: ansible_vars_goss.yml.j2
     dest: "{{ audit_vars_path }}"
     mode: 'go-rwx'
 
-- name: "Pre Audit | Run pre_remediation {{ benchmark }} audit" # noqa name[template]
-  ansible.builtin.command: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -o {{ pre_audit_outfile }} -g \"{{ group_names }}\""
+- name: Pre Audit | Run pre_remediation audit {{ benchmark }}  # noqa name[template]
+  ansible.builtin.shell: "umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ pre_audit_outfile }} -g \"{{ group_names }}\"" # noqa yaml[line-length]
   changed_when: true
   environment:
     AUDIT_BIN: "{{ audit_bin }}"
     AUDIT_CONTENT_LOCATION: "{{ audit_conf_dest | default('/opt') }}"
     AUDIT_FILE: goss.yml
 
-- name: "Pre Audit | Capture audit data if json format"
+- name: Pre Audit | Capture audit data if json format
   when: audit_format == "json"
   block:
-    - name: "Pre Audit | Capture audit data if json format"
+    - name: Pre Audit | Capture audit data if json format
       ansible.builtin.shell: grep -E '\"summary-line.*Count:.*Failed' "{{ pre_audit_outfile }}" | cut -d'"' -f4
-      register: pre_audit_summary
       changed_when: false
+      register: pre_audit_summary
 
-    - name: "Pre Audit | Set Fact for audit summary"
+    - name: Pre Audit | Set Fact for audit summary
       ansible.builtin.set_fact:
         pre_audit_results: "{{ pre_audit_summary.stdout }}"
 
-- name: "Pre Audit | Capture audit data if documentation format"
+- name: Pre Audit | Capture audit data if documentation format
   when: audit_format == "documentation"
   block:
-    - name: "Pre Audit | Capture audit data if documentation format"
+    - name: Pre Audit | Capture audit data if documentation format
       ansible.builtin.shell: tail -2 "{{ pre_audit_outfile }}"  | tac | tr '\n' ' '
-      register: pre_audit_summary
       changed_when: false
+      register: pre_audit_summary
 
-    - name: "Pre Audit | Set Fact for audit summary"
+    - name: Pre Audit | Set Fact for audit summary
       ansible.builtin.set_fact:
         pre_audit_results: "{{ pre_audit_summary.stdout }}"
 
-- name: "Audit_Only | Run Audit Only"
+- name: Audit_Only | Run Audit Only
   when: audit_only
   ansible.builtin.import_tasks:
     file: audit_only.yml

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -26,6 +26,7 @@
 
 - name: "PRELIM | PATCH | Run apt update"
   tags: always
+  changed_when: false
   ansible.builtin.package:
     cache_valid_time: 7200
 
@@ -68,19 +69,22 @@
   tags: always
   ansible.builtin.shell: "grep -Ev 'nologin|/sbin' /etc/passwd | awk -F: '$3 >= {{ min_int_uid }} {print $1}'"
   changed_when: false
-  register: ubtu24stig_interactive_users
-
-- name: "PRELIM | Interactive User account home"
-  tags: always
-  ansible.builtin.shell: 'cat /etc/passwd | grep -Ev "nologin|/sbin" | cut -d: -f6'
-  changed_when: false
-  register: ubtu24stig_interactive_users_home
+  register: prelim_interactive_users
 
 - name: "PRELIM | Gather apt conf file list"
   tags: always
   ansible.builtin.find:
-    paths: /etc/apt/*
+    paths: /etc/apt/
   register: prelim_apt_conf_files
+
+- name: "PRELIM | PATCH | Find all sudoers files."
+  when: ubtu24stig_300019 or ubtu24stig_300020
+  tags: always
+  ansible.builtin.shell: "find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'"
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  register: prelim_sudoers_files
 
 - name: "PRELIM | Gather accounts with empty password fields"
   when: ubtu24stig_300027
@@ -98,7 +102,7 @@
   ansible.builtin.shell: "cat /etc/passwd | awk -F: '($3 == 0 && $1 != \"root\") {i++;print $1 } END {exit i}'"
   changed_when: false
   check_mode: false
-  register: ubtu24stig_uid_zero_accounts_except_root
+  register: prelim_uid_zero_accounts_except_root
 
 - name: "PRELIM | Create list of mount points"
   tags: always
@@ -168,17 +172,11 @@
     recurse: false
   register: prelim_sshd_config_files
 
-- name: PRELIM | Interactive Users
-  tags: always
-  ansible.builtin.shell: "grep -Ev 'nologin|/sbin' /etc/passwd | awk -F: '$3 >= {{ min_int_uid }} {print $1}'"
-  changed_when: false
-  register: ubtu24stig_interactive_users_home
-
 - name: "PRELIM | Discover Gnome Desktop Environment"
   tags: always
   ansible.builtin.stat:
     path: /usr/share/gnome/gnome-version.xml
-  register: ubtu24stig_gnome_present
+  register: prelim_gnome_present
 
 - name: "PRELIM | AUDIT | Wireless adapter pre-requisites"
   when:
@@ -188,9 +186,9 @@
   block:
     - name: "PRELIM | AUDIT | Discover is wireless adapter on system"
       ansible.builtin.shell: find /sys/class/net/*/ -type d -name wireless
-      register: prelim_wireless_adapters
       changed_when: false
       failed_when: prelim_wireless_adapters.rc not in [ 0, 1 ]
+      register: prelim_wireless_adapters
 
     - name: "PRELIM | AUDIT | If wireless adapter present capture module"
       when:

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -89,6 +89,7 @@ ubtu24stig_300031: {{ ubtu24stig_300031 }}
 ubtu24stig_400370: {{ ubtu24stig_400370 }}
 ubtu24stig_600030: {{ ubtu24stig_600030 }}
 ubtu24stig_600130: {{ ubtu24stig_600130 }}
+ubtu24stig_700400: {{ ubtu24stig_700400 }}
 
 #### CAT 2
 ## 10XXXX
@@ -119,10 +120,14 @@ ubtu24stig_102010: {{ ubtu24stig_102010 }}
 ## 20XXXX
 ubtu24stig_200020: {{ ubtu24stig_200020 }}
 ubtu24stig_200040: {{ ubtu24stig_200040 }}
+ubtu24stig_200041: {{ ubtu24stig_200041 }}
+ubtu24stig_200042: {{ ubtu24stig_200042 }}
+ubtu24stig_200043: {{ ubtu24stig_200043 }}
 ubtu24stig_200060: {{ ubtu24stig_200060 }}
 ubtu24stig_200090: {{ ubtu24stig_200090 }}
 ubtu24stig_200250: {{ ubtu24stig_200250 }}
 ubtu24stig_200260: {{ ubtu24stig_200260 }}
+ubtu24stig_200270: {{ ubtu24stig_200270 }}
 ubtu24stig_200280: {{ ubtu24stig_200280 }}
 ubtu24stig_200290: {{ ubtu24stig_200290 }}
 ubtu24stig_200300: {{ ubtu24stig_200300 }}
@@ -145,6 +150,8 @@ ubtu24stig_300012: {{ ubtu24stig_300012 }}
 ubtu24stig_300013: {{ ubtu24stig_300013 }}
 ubtu24stig_300014: {{ ubtu24stig_300014 }}
 ubtu24stig_300016: {{ ubtu24stig_300016 }}
+ubtu24stig_300019: {{ ubtu24stig_300019 }}
+ubtu24stig_300020: {{ ubtu24stig_300020 }}
 ubtu24stig_300021: {{ ubtu24stig_300021 }}
 ubtu24stig_300023: {{ ubtu24stig_300023 }}
 ubtu24stig_300029: {{ ubtu24stig_300029 }}
@@ -206,7 +213,6 @@ ubtu24stig_700150: {{ ubtu24stig_700150 }}
 ubtu24stig_700300: {{ ubtu24stig_700300 }}
 ubtu24stig_700310: {{ ubtu24stig_700310 }}
 ubtu24stig_700320: {{ ubtu24stig_700320 }}
-ubtu24stig_700400: {{ ubtu24stig_700400 }}
 
 ## 900XXX
 ubtu24stig_900040: {{ ubtu24stig_900040 }}
@@ -241,7 +247,6 @@ ubtu24stig_900320: {{ ubtu24stig_900320 }}
 ubtu24stig_900330: {{ ubtu24stig_900330 }}
 ubtu24stig_900340: {{ ubtu24stig_900340 }}
 ubtu24stig_900350: {{ ubtu24stig_900350 }}
-ubtu24stig_900500: {{ ubtu24stig_900500 }}
 ubtu24stig_900510: {{ ubtu24stig_900510 }}
 ubtu24stig_900520: {{ ubtu24stig_900520 }}
 ubtu24stig_900540: {{ ubtu24stig_900540 }}
@@ -263,10 +268,10 @@ ubtu24stig_901300: {{ ubtu24stig_901300 }}
 ubtu24stig_901310: {{ ubtu24stig_901310 }}
 ubtu24stig_901350: {{ ubtu24stig_901350 }}
 ubtu24stig_901380: {{ ubtu24stig_901380 }}
-ubtu24stig_901890: {{ ubtu24stig_901890 }}
 
 ## 909XXX
 ubtu24stig_909000: {{ ubtu24stig_909000 }}
+ubtu24stig_909890: {{ ubtu24stig_909890 }}
 
 #### CAT 3
 ubtu24stig_100010: {{ ubtu24stig_100010 }}

--- a/templates/etc/aide.conf.j2
+++ b/templates/etc/aide.conf.j2
@@ -1,5 +1,4 @@
-## Aide Configuration provide by Ansible-lockdown
-# Sponsored by Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
+{{ file_managed_by_ansible }}
 
 @@define DBDIR /var/lib/aide
 @@define LOGDIR /var/log/aide

--- a/templates/etc/ansible/compliance_facts.j2
+++ b/templates/etc/ansible/compliance_facts.j2
@@ -1,6 +1,4 @@
-# STIG Hardening Carried out
-# Added as part of ansible-lockdown STIG baseline
-# provided by Mindpoint Group - A Tyto Athene Company
+{{ file_managed_by_ansible }}
 
 [lockdown_details]
 # Benchmark release

--- a/templates/etc/audit/rules.d/stig.rules.j2
+++ b/templates/etc/audit/rules.d/stig.rules.j2
@@ -1,5 +1,11 @@
+{{ file_managed_by_ansible }}
 ## Auditd Configured by ansible-lockdown UBUNTU24-STIG
 
+{% if ubtu24stig_200270 %}
+# UBUNTU24-STIG rule 200270
+-w /etc/cron.d/ -p wa -k cronjobs
+-w /var/spool/cron/ -p wa -k cronjobs
+{% endif %}
 {% if ubtu24stig_200280 %}
 # UBUNTU24-STIG rule 200280
 -w /etc/passwd -p wa -k usergroup_modification

--- a/templates/etc/chrony/sources.d/pool.sources.j2
+++ b/templates/etc/chrony/sources.d/pool.sources.j2
@@ -1,6 +1,4 @@
-## Ansible controlled file
-# Sponsored by Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
-# Part of DISA {{ benchmark }} - {{ benchmark_version }}
+{{ file_managed_by_ansible }}
 
 {% for pool in ubtu24stig_time_pool %}
 pool {{ pool.name }} {{ pool.options }}

--- a/templates/etc/chrony/sources.d/server.sources.j2
+++ b/templates/etc/chrony/sources.d/server.sources.j2
@@ -1,6 +1,5 @@
-## Ansible controlled file
-# Sponsored by Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
-# Part of DISA {{ benchmark }} - {{ benchmark_version }}
+{{ file_managed_by_ansible }}
+
 {% for name in ubtu24stig_time_synchronization_servers %}
 server {{ name }} {{ ubtu24stig_chrony_server_options }}
 {% endfor %}

--- a/templates/etc/modprobe.d/module.conf.j2
+++ b/templates/etc/modprobe.d/module.conf.j2
@@ -1,3 +1,4 @@
-# Added as part of STIG requirements
+{{ file_managed_by_ansible }}
+
 install {{ blacklist }} /bin/{{ mod_value | default('false') }}
 blacklist {{ blacklist }}

--- a/templates/etc/profile.d/99-terminal_tmout.sh.j2
+++ b/templates/etc/profile.d/99-terminal_tmout.sh.j2
@@ -1,6 +1,5 @@
-# Timeout profile script created by DISA STIG for UBUNTU24
-## Supplied by ansible-lockdown
-## Sponsored by Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
+{{ file_managed_by_ansible }}
+
 #!/bin/bash
 
 {% if ubtu24stig_200060 %}

--- a/templates/etc/profile.d/ssh_confirm.sh.j2
+++ b/templates/etc/profile.d/ssh_confirm.sh.j2
@@ -1,3 +1,4 @@
+{{ file_managed_by_ansible }}
 #!/bin/bash
 
 if [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ]; then

--- a/templates/etc/rsyslog.d/50-default.conf.j2
+++ b/templates/etc/rsyslog.d/50-default.conf.j2
@@ -1,6 +1,4 @@
-# Set via Ansible-lockdown
-# Sponsored by Mindpoint Group - A Tyto Athene Company / Ansible Lockdown
-# Part of DISA {{ benchmark }} - {{ benchmark_version }}
+{{ file_managed_by_ansible }}
 #
 auth.*,authpriv.* /var/log/secure
 daemon.* /var/log/messages

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -8,32 +8,19 @@ audit_cmd_timeout: 120000
 # if get_audit_binary_method == download change accordingly
 audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
 
-## if get_audit_binary_method - copy the following needs to be updated for your environment
-## it is expected that it will be copied from somewhere accessible to the control node
-## e.g copy from ansible control node to remote host
-audit_bin_copy_location: /some/accessible/path
-
 ### Goss Audit Benchmark file ###
 ## managed by the control audit_content
 # git
 audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
 audit_git_version: "benchmark_{{ benchmark_version }}"
 
-# archive or copy:
-audit_conf_copy: "some path to copy from"
-
-# get_url:
-audit_files_url: "some url maybe s3?"
-
 ## Goss configuration information
-# Where the goss configs and outputs are stored
-audit_out_dir: '/opt'
-# Where the goss audit configuration will be stored
-audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
+# Where the goss audit configuration will be stored - NOTE benchmark-audit is expected
+audit_conf_dir: "{{ audit_conf_dest | default('/opt') }}/{{ benchmark }}-Audit"
 
 # If changed these can affect other products
-pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+pre_audit_outfile: "{{ audit_log_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_log_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
 
 ## The following should not need changing
 
@@ -48,7 +35,7 @@ audit_format: json
 
 audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
 audit_results: |
-  The{% if not audit_only %} pre remediation{% endif %} audit results are: {{ pre_audit_results }}
-  {% if not audit_only %}The post remediation audit results are: {{ post_audit_results }}{% endif %}
+      The{% if not audit_only %} pre remediation{% endif %} audit results are: {{ pre_audit_results }}
+      {% if not audit_only %}The post remediation audit results are: {{ post_audit_results }}{% endif %}
 
-  Full breakdown can be found in {{ audit_log_dir }}
+      Full breakdown can be found in {{ audit_log_dir }}

--- a/vars/is_container.yml
+++ b/vars/is_container.yml
@@ -1,7 +1,131 @@
 ---
 
-# File to skip controls if container
-# Based on standard image no changes
-# it expected all pkgs required for the container are already installed
+# vars/is_container.yml
+# Disables rules that cannot meaningfully run inside a container.
+# Loaded by tasks/main.yml when ansible_connection is a docker variant
+# (system_is_container=true). Per lesson #27.
+#
+# Scope: kernel-level / hardware-level / boot-time / netfilter / mount-table
+# rules. SSH cipher / PAM / SSSD / sudo config rules are container-safe
+# even when their titles mention FIPS/audit and are NOT disabled here.
 
-## controls
+# ==============================================================================
+# auditd / audit subsystem (67 rules)
+# ==============================================================================
+ubtu24stig_100400: false
+ubtu24stig_100410: false
+ubtu24stig_200270: false
+ubtu24stig_200280: false
+ubtu24stig_200290: false
+ubtu24stig_200300: false
+ubtu24stig_200310: false
+ubtu24stig_200320: false
+ubtu24stig_200580: false
+ubtu24stig_300029: false
+ubtu24stig_500010: false
+ubtu24stig_900040: false
+ubtu24stig_900050: false
+ubtu24stig_900060: false
+ubtu24stig_900070: false
+ubtu24stig_900080: false
+ubtu24stig_900090: false
+ubtu24stig_900100: false
+ubtu24stig_900110: false
+ubtu24stig_900120: false
+ubtu24stig_900130: false
+ubtu24stig_900140: false
+ubtu24stig_900150: false
+ubtu24stig_900160: false
+ubtu24stig_900170: false
+ubtu24stig_900180: false
+ubtu24stig_900190: false
+ubtu24stig_900200: false
+ubtu24stig_900210: false
+ubtu24stig_900220: false
+ubtu24stig_900230: false
+ubtu24stig_900240: false
+ubtu24stig_900250: false
+ubtu24stig_900260: false
+ubtu24stig_900270: false
+ubtu24stig_900280: false
+ubtu24stig_900290: false
+ubtu24stig_900300: false
+ubtu24stig_900310: false
+ubtu24stig_900320: false
+ubtu24stig_900330: false
+ubtu24stig_900340: false
+ubtu24stig_900350: false
+ubtu24stig_900510: false
+ubtu24stig_900520: false
+ubtu24stig_900540: false
+ubtu24stig_900590: false
+ubtu24stig_900600: false
+ubtu24stig_900610: false
+ubtu24stig_900730: false
+ubtu24stig_900740: false
+ubtu24stig_900750: false
+ubtu24stig_901220: false
+ubtu24stig_901230: false
+ubtu24stig_901240: false
+ubtu24stig_901250: false
+ubtu24stig_901300: false
+ubtu24stig_901310: false
+ubtu24stig_901350: false
+ubtu24stig_901380: false
+ubtu24stig_909000: false
+ubtu24stig_909890: false
+ubtu24stig_100450: false
+ubtu24stig_900920: false
+ubtu24stig_900950: false
+ubtu24stig_900960: false
+ubtu24stig_900980: false
+
+# ==============================================================================
+# GRUB / kernel / sysctl / modprobe (8 rules)
+# ==============================================================================
+ubtu24stig_102000: false
+ubtu24stig_102010: false
+ubtu24stig_300039: false
+ubtu24stig_600070: false
+ubtu24stig_600140: false
+ubtu24stig_600190: false
+ubtu24stig_600230: false
+ubtu24stig_700310: false
+
+# ==============================================================================
+# FIPS kernel-mode (configuration-only FIPS rules like SSH ciphers are container-safe) (1 rules)
+# ==============================================================================
+ubtu24stig_600030: false
+
+# ==============================================================================
+# AppArmor (3 rules)
+# ==============================================================================
+ubtu24stig_100500: false
+ubtu24stig_100510: false
+ubtu24stig_100660: false
+
+# ==============================================================================
+# firewall (UFW / nftables / iptables) (4 rules)
+# ==============================================================================
+ubtu24stig_100300: false
+ubtu24stig_100310: false
+ubtu24stig_300041: false
+ubtu24stig_600200: false
+
+# ==============================================================================
+# time sync (chrony / ntp) (3 rules)
+# ==============================================================================
+ubtu24stig_100010: false
+ubtu24stig_100020: false
+ubtu24stig_100700: false
+
+# ==============================================================================
+# environment-impossible (4 rules) — depend on hardware, kernel features, or
+# external infrastructure (CPU NX bit, disk encryption hardware, DOD PKI
+# certificate plumbing, SSSD identity provider) that no Docker container
+# environment can provide
+# ==============================================================================
+ubtu24stig_400340: false
+ubtu24stig_600060: false
+ubtu24stig_600090: false
+ubtu24stig_700300: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,10 +1,7 @@
 ---
 # vars file for UBUNTU24-STIG
 
-min_ansible_version: 2.12.1
-
-# Set dynamically if discovered to be non UEFI boot
-ubtu24stig_legacy_boot: false
+min_ansible_version: 2.16.1
 
 # tweak role to run in a non-privileged container (default value)- dynamically discovered in tasks/main.yml
 system_is_container: false
@@ -15,9 +12,6 @@ ubtu24stig_subscribed: false
 # Used to control warning summary
 warn_control_list: ""
 warn_count: 0
-
-# Allow automated discovery of uids
-discover_int_uid: true
 
 # Default for facts
 reboot_required: false
@@ -41,3 +35,9 @@ ubtu24stig_dod_kex:
   - diffie-hellman-group-exchange-sha256
   - diffie-hellman-group16-sha512
   - diffie-hellman-group14-sha256
+
+company_title: 'MindPoint Group - A Tyto Athene Company'
+file_managed_by_ansible: |-
+  # File managed by ansible as part of {{ benchmark }} benchmark
+  # As part of Ansible-lockdown
+  # Provided by {{ company_title }}


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

Full V1R3 QA pass on Ubuntu 24.04 STIG covering hygiene, SV-* tag alignment, changelog, and a cross-port of a community contribution.

N/A - no open community issues at PR creation time.

**Enhancements:**

- Hygiene sweep across `meta/`, `LICENSE`, `README.md`, `.gitignore`, file modes
- SV-* tag alignment against V1R3 SCAP canonical values
- 2026 May Updates section added to `CHANGELOG.md` (full prior history preserved)
- Ports public commit ba91122 (fix: using list as boolean condition) for UBTU-24-900920 mounts selectattr check - the private remediation was using \`is defined\` on a selectattr generator (always-truthy); replaced with \`| list | length > 0\` per the public contribution
- Molecule scenarios added (\`default\` with converge/molecule/prepare)
- New task file \`tasks/Cat1/UBTU24-70xxxx.yml\`
- CONTRIBUTING moved from \`.md\` to \`.rst\` to match other Lockdown repos
- \`vars/is_container.yml\` significantly expanded with environment-impossible rules
- Workflow alignment with private QA conventions

**How has this been tested?:**

- Full QA pass on \`Private-UBUNTU24-STIG benchmark_v1r3\` (commits 8d99a83, 4b38fdc, 8b951f9, a26fbee)
- Cross-repo validation against \`UBUNTU24-STIG-Audit benchmark_v1.3.0\` - clean
- Branding/badge sanity sweep against the staged tree before commit - clean
